### PR TITLE
Meta: Moved .gitignore to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*/node_modules
+*/.serverless
+*/target
+*/rustfmt.toml

--- a/data-collector/.gitignore
+++ b/data-collector/.gitignore
@@ -1,4 +1,0 @@
-node_modules
-.serverless
-target
-rustfmt.toml


### PR DESCRIPTION
# What does this PR change?
- Moves gitignore file to project root

# Why is it important?
Reduces duplication of gitignore files and the risk of them getting out of sync between components

# Checklist
- [X] Tests added/updated as appropriate
- [X] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added