### PR TITLE
docs: Made reference to Kiln architecture diagram in project README a relative link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ All Kiln Connectors are Kafka consumers that process the events in the tool outp
 
 Kiln Security Scanners are docker containers with security tools baked into the image and also include a small binary that takes the output from the tool and sends it to the Kiln Data Collector to be recorded.
 
-![Kiln architecture diagram](https://github.com/simplybusiness/Kiln/blob/7cafc19b16ca1c13f4e187e6309b2efc16eed7bc/docs/images/Kiln%20Architecture%20diagram.png)
+![Kiln architecture diagram](docs/images/Kiln%20Architecture%20diagram.png)
 
 ## Contributing
 To contribute to Kiln, you'll need the following tools installed:


### PR DESCRIPTION
# What does this PR change?
- Makes link to Kiln architecture diagram a relative link, instead of an absolute link to a commit blob.

# Why is it important?
Reduces effort involved in updating the architecture diagram by removing the need for two commits: One to update the diagram file and a second to update the link in the project README.

Also makes the process less error prone by not forcing a developer to remember that second step.

# Checklist
- [x] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
