### PR TITLE
CI: Splitting data-collector CI into several jobs 

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -8,17 +8,35 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v1
-            - name: Install dependencies
-              run: yarn
-              working-directory: data-collector/
             - name: Build
               run: cargo build
               working-directory: data-collector/
+    test-data-collector:
+        name: Data-collector tests
+        runs-on: ubuntu-18.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1
+            - name: Test
+              run: cargo test
+              working-directory: data-collector/
+    lint-data-collector:
+        name: Data-collector lint
+        runs-on: ubuntu-18.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1
             - name: Lint
               run: cargo clippy
               working-directory: data-collector/
-            - name: Test
-              run: cargo test
+    test-serverless-package-data-collector:
+        name: Data-collector serverless package
+        runs-on: ubuntu-18.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1
+            - name: Install dependencies
+              run: yarn
               working-directory: data-collector/
             - name: Serverless package
               run: npx serverless package


### PR DESCRIPTION
# What does this PR change?
- Splits data-collector CI build into several jobs to take advantage of parallelisation

# Why is it important?
- This change reduces the build time by approximately 4 minutes, allowing for faster feedback on changes

# Checklist
- [x] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
