### PR TITLE
Kiln_lib types Avro Impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,7 @@ version = "0.1.0"
 dependencies = [
  "avro-rs 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambda_http 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/kiln_lib/Cargo.toml
+++ b/kiln_lib/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+avro-rs = "0.6"
 chrono = "0.4"
 lambda_http = "0.1"
 http = "0.1"
@@ -12,4 +13,3 @@ serde = { version = "1.0", features = ["derive"] }
 regex = "1.0"
 
 [dev-dependencies]
-avro-rs = "0.6"

--- a/kiln_lib/Cargo.toml
+++ b/kiln_lib/Cargo.toml
@@ -11,5 +11,4 @@ http = "0.1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 regex = "1.0"
-
-[dev-dependencies]
+failure = "0.1"

--- a/kiln_lib/README.md
+++ b/kiln_lib/README.md
@@ -16,6 +16,6 @@ In Kiln, messages are serialised to the [Apache Avro format](https://avro.apache
         {"name": "start_time", "type": "string"},
         {"name": "end_time", "type": "string"},
         {"name": "environment", "type": "string"},
-        {"name": "tool_version", "type": "string"}
+        {"name": "tool_version", "type": ["null", "string"]}
     ]
 }

--- a/kiln_lib/src/lib.rs
+++ b/kiln_lib/src/lib.rs
@@ -284,7 +284,7 @@ pub mod tool_report {
     use regex::Regex;
 
     #[allow(dead_code)]
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub struct ToolReport {
         pub application_name: ApplicationName,
         pub git_branch: GitBranch,
@@ -298,7 +298,7 @@ pub mod tool_report {
         pub tool_version:ToolVersion
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub struct ApplicationName(String);
 
     impl TryFrom<String> for ApplicationName {
@@ -319,7 +319,7 @@ pub mod tool_report {
         }
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub struct GitBranch(String);
     
     impl TryFrom<String> for GitBranch{
@@ -340,7 +340,7 @@ pub mod tool_report {
         }
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub struct GitCommitHash(String);
 
     impl TryFrom<String> for GitCommitHash {
@@ -366,7 +366,7 @@ pub mod tool_report {
         }
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub struct ToolName(String);
 
     impl TryFrom<String> for ToolName{
@@ -387,7 +387,7 @@ pub mod tool_report {
         }
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub struct ToolOutput(String);
 
     impl TryFrom<String> for ToolOutput {
@@ -408,7 +408,7 @@ pub mod tool_report {
         }
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub struct ToolVersion(Option<String>);
 
     impl TryFrom<Option<String>> for ToolVersion {
@@ -437,7 +437,7 @@ pub mod tool_report {
         }
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub enum OutputFormat {
         JSON,
         PlainText,
@@ -452,7 +452,7 @@ pub mod tool_report {
         }
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub enum Environment {
         Local,
         CI,

--- a/kiln_lib/src/lib.rs
+++ b/kiln_lib/src/lib.rs
@@ -259,6 +259,13 @@ pub mod validation {
                 error_message: "Tool version present but empty".into(),
             }
         }
+
+        pub fn avro_schema_validation_failed() -> ValidationError {
+            ValidationError {
+                error_code: 130,
+                error_message: "Tried to deserialise a ToolReport from Avro but value didn't pass schema validation".into()
+            }
+        }
     }
 
     impl IntoResponse for ValidationError {

--- a/kiln_lib/src/lib.rs
+++ b/kiln_lib/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod avro_schema {
-    pub const TOOL_REPORT_SCHEMA: &'static str = r#"
+    pub const TOOL_REPORT_SCHEMA: &str = r#"
         {
             "type": "record",
             "name": "ToolReport",

--- a/kiln_lib/src/lib.rs
+++ b/kiln_lib/src/lib.rs
@@ -445,7 +445,10 @@ pub mod tool_report {
 
     impl std::fmt::Display for OutputFormat {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            write!(f, "{}", self)
+            match self {
+                OutputFormat::JSON => write!(f, "JSON"),
+                OutputFormat::PlainText => write!(f, "PlainText")
+            }
         }
     }
 
@@ -457,7 +460,10 @@ pub mod tool_report {
 
     impl std::fmt::Display for Environment {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            write!(f, "{}", self)
+            match self {
+                Environment::Local => write!(f, "Local"),
+                Environment::CI => write!(f, "CI")
+            }
         }
     }
 

--- a/kiln_lib/src/lib.rs
+++ b/kiln_lib/src/lib.rs
@@ -272,11 +272,13 @@ pub mod validation {
 }
 
 pub mod tool_report {
+    use crate::avro_schema::TOOL_REPORT_SCHEMA;
     use crate::validation::ValidationError;
 
     use std::convert::TryFrom;
 
-    
+    use avro_rs::types::{Record, ToAvro};
+    use avro_rs::schema::Schema;
     use chrono::{DateTime, Utc};
     use serde_json::value::Value;
     use regex::Regex;
@@ -485,6 +487,29 @@ pub mod tool_report {
                 environment,
                 tool_version,
             })
+        }
+    }
+
+    impl ToAvro for ToolReport {
+        fn avro(self) -> avro_rs::types::Value {
+            let schema = Schema::parse_str(TOOL_REPORT_SCHEMA).unwrap();
+            let mut record = Record::new(&schema).unwrap();
+            record.put("application_name", self.application_name.to_string());
+            record.put("git_branch", self.git_branch.to_string());
+            record.put("git_commit_hash", self.git_commit_hash.to_string());
+            record.put("tool_name", self.tool_name.to_string());
+            record.put("tool_output", self.tool_output.to_string());
+            record.put("output_format", self.output_format.to_string());
+            record.put("start_time", self.start_time.to_string());
+            record.put("end_time", self.end_time.to_string());
+            record.put("environment", self.environment.to_string());
+            let tool_version = self.tool_version.to_string();
+            if tool_version.is_empty() {
+                record.put("tool_version", avro_rs::types::Value::Null);
+            } else {
+                record.put("tool_version", tool_version);
+            }
+            avro_rs::types::Value::Record(record.fields)
         }
     }
 

--- a/kiln_lib/src/lib.rs
+++ b/kiln_lib/src/lib.rs
@@ -13,7 +13,7 @@ pub mod avro_schema {
                 {"name": "start_time", "type": "string"},
                 {"name": "end_time", "type": "string"},
                 {"name": "environment", "type": "string"},
-                {"name": "tool_version", "type": "string"}
+                {"name": "tool_version", "type": ["null", "string"]}
             ]
         }
     "#;

--- a/kiln_lib/src/lib.rs
+++ b/kiln_lib/src/lib.rs
@@ -311,6 +311,12 @@ pub mod tool_report {
         }
     }
 
+    impl std::fmt::Display for ApplicationName {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
     #[derive(Debug, PartialEq)]
     pub struct GitBranch(String);
     
@@ -323,6 +329,12 @@ pub mod tool_report {
             } else {
                 Ok(GitBranch(value))
             }
+        }
+    }
+
+    impl std::fmt::Display for GitBranch {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{}", self.0)
         }
     }
 
@@ -346,6 +358,12 @@ pub mod tool_report {
         }
     }
 
+    impl std::fmt::Display for GitCommitHash {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
     #[derive(Debug, PartialEq)]
     pub struct ToolName(String);
 
@@ -361,6 +379,12 @@ pub mod tool_report {
         }
     }
 
+    impl std::fmt::Display for ToolName {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
     #[derive(Debug, PartialEq)]
     pub struct ToolOutput(String);
 
@@ -373,6 +397,12 @@ pub mod tool_report {
             } else {
                 Ok(ToolOutput(value))
             }
+        }
+    }
+
+    impl std::fmt::Display for ToolOutput {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{}", self.0)
         }
     }
 
@@ -396,16 +426,37 @@ pub mod tool_report {
         }
     }
 
+    impl std::fmt::Display for ToolVersion {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            match &self.0 {
+                Some(x) => write!(f, "{}", x),
+                None => write!(f, "")
+            }
+        }
+    }
+
     #[derive(Debug, PartialEq)]
     pub enum OutputFormat {
         JSON,
         PlainText,
     }
 
+    impl std::fmt::Display for OutputFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{}", self)
+        }
+    }
+
     #[derive(Debug, PartialEq)]
     pub enum Environment {
         Local,
         CI,
+    }
+
+    impl std::fmt::Display for Environment {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{}", self)
+        }
     }
 
     impl TryFrom<&Value> for ToolReport {


### PR DESCRIPTION
# What does this PR change?
- Fixes the Avro schema for ToolReport by making tool_version field a Union of Null or String to represent that it is optional
- Adds Display Impls for all ToolReport fields
- Adds ToAvro impls for ToolReport
- Adds TryFrom impls for Avro Values to ToolReport fields

# Why is it important?
- Enabled converting between Avro and ToolReports with correct validation, which unlocks #37 

# Checklist
- [x] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
