### PR TITLE
kiln_lib: Added From<DateTime<Utc>> impl for StartTime and EndTime

### DIFF
--- a/kiln_lib/src/lib.rs
+++ b/kiln_lib/src/lib.rs
@@ -468,12 +468,24 @@ pub mod tool_report {
         }
     }
 
+    impl From<DateTime<Utc>> for StartTime {
+        fn from(dt: DateTime<Utc>) -> Self {
+            Self(dt)
+        }
+    }
+
     #[derive(Clone, Debug, PartialEq)]
     pub struct EndTime(DateTime<Utc>);
 
     impl std::fmt::Display for EndTime {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             write!(f, "{}", self.0.to_rfc3339())
+        }
+    }
+
+    impl From<DateTime<Utc>> for EndTime {
+        fn from(dt: DateTime<Utc>) -> Self {
+            Self(dt)
         }
     }
 


### PR DESCRIPTION
# What does this PR change?
- Added From<DateTime<Utc>> impl for StartTime and EndTime

# Why is it important?
- Allows consuming code to create StartTime and EndTime types

# Checklist
- [x] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
