### PR TITLE
Kiln_lib: Fixed avro serialisation

### DIFF
--- a/kiln_lib/Cargo.lock
+++ b/kiln_lib/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/kiln_lib/Cargo.toml
+++ b/kiln_lib/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 avro-rs = "0.6"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 actix-web = "1.0"
 http = "0.1"
 serde_json = "1.0"


### PR DESCRIPTION
# What does this PR change?
- Expands the Avro round trip unit test to include going down to bytes to check schema matches ToolReport struct
- Switched to using the serde approach to Avro serialisation
- Corrected mistakes in ToolReport Avro schema around enums

# Why is it important?
- Fixes broken Avro serialisation

# Checklist
- [x] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
