### PR TITLE
CI: Cargo caching

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -2,8 +2,8 @@ name: CI
 on: [push]
 
 jobs:
-    build-data-collector:
-        name: Data-collector build
+    data-collector:
+        name: Data-collector CI
         runs-on: ubuntu-18.04
         steps:
             - name: Checkout
@@ -12,79 +12,28 @@ jobs:
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/registry
-                key: ${{ runner.os }}-data-collector-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: data-collector/
+                key: ${{ runner.os }}-data-collector-cargo-registry-${{ hashFiles('data-collector/Cargo.lock') }}
             - name: Cache cargo index
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/git
-                key: ${{ runner.os }}-data-collector-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: data-collector/
+                key: ${{ runner.os }}-data-collector-cargo-index-${{ hashFiles('data-collector/Cargo.lock') }}
             - name: Cache cargo build
               uses: actions/cache@v1
               with:
                 path: target
-                key: ${{ runner.os }}-data-collector-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: data-collector/
+                key: ${{ runner.os }}-data-collector-cargo-build-target-${{ hashFiles('data-collector/Cargo.lock') }}
             - name: Build
               run: cargo build
               working-directory: data-collector/
-    test-data-collector:
-        name: Data-collector tests
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Cache cargo registry
-              uses: actions/cache@v1
-              with:
-                path: ~/.cargo/registry
-                key: ${{ runner.os }}-data-collector-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: data-collector/
-            - name: Cache cargo index
-              uses: actions/cache@v1
-              with:
-                path: ~/.cargo/git
-                key: ${{ runner.os }}-data-collector-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: data-collector/
-            - name: Cache cargo build
-              uses: actions/cache@v1
-              with:
-                path: target
-                key: ${{ runner.os }}-data-collector-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: data-collector/
             - name: Test
               run: cargo test
-              working-directory: data-collector/
-    lint-data-collector:
-        name: Data-collector lint
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Cache cargo registry
-              uses: actions/cache@v1
-              with:
-                path: ~/.cargo/registry
-                key: ${{ runner.os }}-data-collector-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: data-collector/
-            - name: Cache cargo index
-              uses: actions/cache@v1
-              with:
-                path: ~/.cargo/git
-                key: ${{ runner.os }}-data-collector-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: data-collector/
-            - name: Cache cargo build
-              uses: actions/cache@v1
-              with:
-                path: target
-                key: ${{ runner.os }}-data-collector-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
               working-directory: data-collector/
             - name: Lint
               run: cargo clippy
               working-directory: data-collector/
-    build-kiln_lib:
-        name: Kiln_lib build
+    kiln_lib:
+        name: Kiln_lib CI 
         runs-on: ubuntu-18.04
         steps:
             - name: Checkout
@@ -93,73 +42,25 @@ jobs:
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/registry
-                key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+                key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('kiln_lib/Cargo.lock') }}
               working-directory: kiln_lib/
             - name: Cache cargo index
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/git
-                key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+                key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('kiln_lib/Cargo.lock') }}
               working-directory: kiln_lib/
             - name: Cache cargo build
               uses: actions/cache@v1
               with:
                 path: target
-                key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+                key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('kiln_lib/Cargo.lock') }}
               working-directory: kiln_lib/
             - name: Build
               run: cargo build
               working-directory: kiln_lib/
-    test-kiln-lib:
-        name: Kiln_lib tests
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Cache cargo registry
-              uses: actions/cache@v1
-              with:
-                path: ~/.cargo/registry
-                key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: kiln_lib/
-            - name: Cache cargo index
-              uses: actions/cache@v1
-              with:
-                path: ~/.cargo/git
-                key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: kiln_lib/
-            - name: Cache cargo build
-              uses: actions/cache@v1
-              with:
-                path: target
-                key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: kiln_lib/
             - name: Test
               run: cargo test
-              working-directory: kiln_lib/
-    lint-kiln-lib:
-        name: Kiln_lib lint
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Cache cargo registry
-              uses: actions/cache@v1
-              with:
-                path: ~/.cargo/registry
-                key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: kiln_lib/
-            - name: Cache cargo index
-              uses: actions/cache@v1
-              with:
-                path: ~/.cargo/git
-                key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-              working-directory: kiln_lib/
-            - name: Cache cargo build
-              uses: actions/cache@v1
-              with:
-                path: target
-                key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
               working-directory: kiln_lib/
             - name: Lint
               run: cargo clippy

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -6,6 +6,21 @@ jobs:
         name: Data-collector build
         runs-on: ubuntu-18.04
         steps:
+            - name: Cache cargo registry
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/registry
+                key: ${{ runner.os }}-data-collector-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo index
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/git
+                key: ${{ runner.os }}-data-collector-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo build
+              uses: actions/cache@v1
+              with:
+                path: target
+                key: ${{ runner.os }}-data-collector-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
             - name: Checkout
               uses: actions/checkout@v1
             - name: Build
@@ -15,6 +30,21 @@ jobs:
         name: Data-collector tests
         runs-on: ubuntu-18.04
         steps:
+            - name: Cache cargo registry
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/registry
+                key: ${{ runner.os }}-data-collector-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo index
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/git
+                key: ${{ runner.os }}-data-collector-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo build
+              uses: actions/cache@v1
+              with:
+                path: target
+                key: ${{ runner.os }}-data-collector-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
             - name: Checkout
               uses: actions/checkout@v1
             - name: Test
@@ -24,6 +54,21 @@ jobs:
         name: Data-collector lint
         runs-on: ubuntu-18.04
         steps:
+            - name: Cache cargo registry
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/registry
+                key: ${{ runner.os }}-data-collector-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo index
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/git
+                key: ${{ runner.os }}-data-collector-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo build
+              uses: actions/cache@v1
+              with:
+                path: target
+                key: ${{ runner.os }}-data-collector-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
             - name: Checkout
               uses: actions/checkout@v1
             - name: Lint
@@ -33,6 +78,21 @@ jobs:
         name: Kiln_lib build
         runs-on: ubuntu-18.04
         steps:
+            - name: Cache cargo registry
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/registry
+                key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo index
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/git
+                key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo build
+              uses: actions/cache@v1
+              with:
+                path: target
+                key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
             - name: Checkout
               uses: actions/checkout@v1
             - name: Build
@@ -42,6 +102,21 @@ jobs:
         name: Kiln_lib tests
         runs-on: ubuntu-18.04
         steps:
+            - name: Cache cargo registry
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/registry
+                key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo index
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/git
+                key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo build
+              uses: actions/cache@v1
+              with:
+                path: target
+                key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
             - name: Checkout
               uses: actions/checkout@v1
             - name: Test
@@ -51,6 +126,21 @@ jobs:
         name: Kiln_lib lint
         runs-on: ubuntu-18.04
         steps:
+            - name: Cache cargo registry
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/registry
+                key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo index
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/git
+                key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache cargo build
+              uses: actions/cache@v1
+              with:
+                path: target
+                key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
             - name: Checkout
               uses: actions/checkout@v1
             - name: Lint

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -43,19 +43,16 @@ jobs:
               with:
                 path: ~/.cargo/registry
                 key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('kiln_lib/Cargo.lock') }}
-              working-directory: kiln_lib/
             - name: Cache cargo index
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/git
                 key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('kiln_lib/Cargo.lock') }}
-              working-directory: kiln_lib/
             - name: Cache cargo build
               uses: actions/cache@v1
               with:
                 path: target
                 key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('kiln_lib/Cargo.lock') }}
-              working-directory: kiln_lib/
             - name: Build
               run: cargo build
               working-directory: kiln_lib/

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -6,23 +6,26 @@ jobs:
         name: Data-collector build
         runs-on: ubuntu-18.04
         steps:
+            - name: Checkout
+              uses: actions/checkout@v1
             - name: Cache cargo registry
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/registry
                 key: ${{ runner.os }}-data-collector-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: data-collector/
             - name: Cache cargo index
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/git
                 key: ${{ runner.os }}-data-collector-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: data-collector/
             - name: Cache cargo build
               uses: actions/cache@v1
               with:
                 path: target
                 key: ${{ runner.os }}-data-collector-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-            - name: Checkout
-              uses: actions/checkout@v1
+              working-directory: data-collector/
             - name: Build
               run: cargo build
               working-directory: data-collector/
@@ -30,23 +33,26 @@ jobs:
         name: Data-collector tests
         runs-on: ubuntu-18.04
         steps:
+            - name: Checkout
+              uses: actions/checkout@v1
             - name: Cache cargo registry
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/registry
                 key: ${{ runner.os }}-data-collector-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: data-collector/
             - name: Cache cargo index
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/git
                 key: ${{ runner.os }}-data-collector-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: data-collector/
             - name: Cache cargo build
               uses: actions/cache@v1
               with:
                 path: target
                 key: ${{ runner.os }}-data-collector-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-            - name: Checkout
-              uses: actions/checkout@v1
+              working-directory: data-collector/
             - name: Test
               run: cargo test
               working-directory: data-collector/
@@ -54,23 +60,26 @@ jobs:
         name: Data-collector lint
         runs-on: ubuntu-18.04
         steps:
+            - name: Checkout
+              uses: actions/checkout@v1
             - name: Cache cargo registry
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/registry
                 key: ${{ runner.os }}-data-collector-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: data-collector/
             - name: Cache cargo index
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/git
                 key: ${{ runner.os }}-data-collector-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: data-collector/
             - name: Cache cargo build
               uses: actions/cache@v1
               with:
                 path: target
                 key: ${{ runner.os }}-data-collector-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-            - name: Checkout
-              uses: actions/checkout@v1
+              working-directory: data-collector/
             - name: Lint
               run: cargo clippy
               working-directory: data-collector/
@@ -78,23 +87,26 @@ jobs:
         name: Kiln_lib build
         runs-on: ubuntu-18.04
         steps:
+            - name: Checkout
+              uses: actions/checkout@v1
             - name: Cache cargo registry
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/registry
                 key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: kiln_lib/
             - name: Cache cargo index
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/git
                 key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: kiln_lib/
             - name: Cache cargo build
               uses: actions/cache@v1
               with:
                 path: target
                 key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-            - name: Checkout
-              uses: actions/checkout@v1
+              working-directory: kiln_lib/
             - name: Build
               run: cargo build
               working-directory: kiln_lib/
@@ -102,23 +114,26 @@ jobs:
         name: Kiln_lib tests
         runs-on: ubuntu-18.04
         steps:
+            - name: Checkout
+              uses: actions/checkout@v1
             - name: Cache cargo registry
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/registry
                 key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: kiln_lib/
             - name: Cache cargo index
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/git
                 key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: kiln_lib/
             - name: Cache cargo build
               uses: actions/cache@v1
               with:
                 path: target
                 key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-            - name: Checkout
-              uses: actions/checkout@v1
+              working-directory: kiln_lib/
             - name: Test
               run: cargo test
               working-directory: kiln_lib/
@@ -126,23 +141,26 @@ jobs:
         name: Kiln_lib lint
         runs-on: ubuntu-18.04
         steps:
+            - name: Checkout
+              uses: actions/checkout@v1
             - name: Cache cargo registry
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/registry
                 key: ${{ runner.os }}-kiln-lib-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: kiln_lib/
             - name: Cache cargo index
               uses: actions/cache@v1
               with:
                 path: ~/.cargo/git
                 key: ${{ runner.os }}-kiln-lib-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+              working-directory: kiln_lib/
             - name: Cache cargo build
               uses: actions/cache@v1
               with:
                 path: target
                 key: ${{ runner.os }}-kiln-lib-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-            - name: Checkout
-              uses: actions/checkout@v1
+              working-directory: kiln_lib/
             - name: Lint
               run: cargo clippy
               working-directory: kiln_lib/


### PR DESCRIPTION
# What does this PR change?
- Alters structure of CI jobs to collapse each component into a single job, rather, than separate jobs for build, test and lint
- Add steps for caching Cargo index, build cache etc between jobs, hashed on the Cargo.lock for each component

# Why is it important?
- Should reduce build time by not requiring dependencies to be rebuilt for every push to GitHub

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
