### PR TITLE
Kiln lib git branch name optional

### DIFF
--- a/kiln_lib/README.md
+++ b/kiln_lib/README.md
@@ -3,12 +3,13 @@
 ## Avro Schema
 In Kiln, messages are serialised to the [Apache Avro format](https://avro.apache.org/docs/current/) before being sent to an Apache Kafka topic to be recorded. Below is the schema used to encode messages in Avro. Note that every field is recorded as a string. This is intentional, because all data validation should happen by building an instance of the ToolReport struct, either from JSON values in the case of the data-collector, or from string using the TryFrom<String> implementations for fields in the structy directly for other components. This scheme is validated using a test that parses the schema, so any invalid changes should be caught by CI.
 
+```
 {
     "type": "record",
     "name": "ToolReport",
     "fields": [
         {"name": "application_name", "type": "string"},
-        {"name": "git_branch", "type": "string"},
+        {"name": "git_branch", "type": ["null" ,"string"]},
         {"name": "git_commit_hash", "type": "string"},
         {"name": "tool_name", "type": "string"},
         {"name": "tool_output", "type": "string"},
@@ -19,3 +20,4 @@ In Kiln, messages are serialised to the [Apache Avro format](https://avro.apache
         {"name": "tool_version", "type": ["null", "string"]}
     ]
 }
+```


### PR DESCRIPTION
# What does this PR change?
Makes the git branch name optional

# Why is it important?
Allows us to gather git metadata when in detached head state

# Checklist
- [x] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
