### PR TITLE
Kiln_lib: Fix typo in Avro schema

### DIFF
--- a/kiln_lib/README.md
+++ b/kiln_lib/README.md
@@ -9,14 +9,14 @@ In Kiln, messages are serialised to the [Apache Avro format](https://avro.apache
     "name": "ToolReport",
     "fields": [
         {"name": "application_name", "type": "string"},
-        {"name": "git_branch", "type": ["null" ,"string"]},
+        {"name": "git_branch", "type": ["null", "string"]},
         {"name": "git_commit_hash", "type": "string"},
         {"name": "tool_name", "type": "string"},
         {"name": "tool_output", "type": "string"},
-        {"name": "output_format", "type": "string"},
+        {"name": "output_format", "type": {"type": "enum", "name": "OutputFormat", "symbols": ["JSON", "PlainText"]}},
         {"name": "start_time", "type": "string"},
         {"name": "end_time", "type": "string"},
-        {"name": "environment", "type": "string"},
+        {"name": "environment", "type": {"type": "enum", "name": "Environment", "symbols": ["Local", "CI"]}},
         {"name": "tool_version", "type": ["null", "string"]}
     ]
 }

--- a/kiln_lib/src/lib.rs
+++ b/kiln_lib/src/lib.rs
@@ -9,7 +9,7 @@ pub mod avro_schema {
                 {"name": "git_commit_hash", "type": "string"},
                 {"name": "tool_name", "type": "string"},
                 {"name": "tool_output", "type": "string"},
-                {"name": "output_format", "type": {"type": "enum", "name": "OutputFormat", "symbols": ["JSON", "Plaintext"]}},
+                {"name": "output_format", "type": {"type": "enum", "name": "OutputFormat", "symbols": ["JSON", "PlainText"]}},
                 {"name": "start_time", "type": "string"},
                 {"name": "end_time", "type": "string"},
                 {"name": "environment", "type": {"type": "enum", "name": "Environment", "symbols": ["Local", "CI"]}},


### PR DESCRIPTION
# What does this PR change?
Corrects a typo in Kiln_lib Avro schema to match casing of PlainText used elsewhere

# Why is it important?
Consistency throughout codebase 

# Checklist
- [ ] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
