### PR TITLE
Meta: Update Makefiles to build and tag master and released docker images with clearer naming format

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -92,8 +92,11 @@ jobs:
                 version: 0.22.2
             - name: Checkout
               uses: actions/checkout@v1
-            - name: Build data-collector
-              run: cargo make build-data-collector-docker
+            - name: Build data-collector for musl-libc
+              run: cargo make musl-build
+              working-directory: data-collector
+            - name: Build data-collector docker image
+              run: cargo make build-data-collector-docker-image
               working-directory: data-collector
     build-bundler-audit-docker:
         name: Build Bundler-Audit tool docker image

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -93,7 +93,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v1
             - name: Build data-collector
-              run: cargo make build-data-collector-master-docker
+              run: cargo make build-data-collector-docker
               working-directory: data-collector
     build-bundler-audit-docker:
         name: Build Bundler-Audit tool docker image

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -98,7 +98,7 @@ jobs:
               run: cargo make pre-build-bundler-audit-docker
               working-directory: tool-images/ruby/bundler-audit
             - name: Build bundler-audit
-              run: cargo make build-bundler-audit-docker
+              run: cargo make build-bundler-audit-master-docker
               working-directory: tool-images/ruby/bundler-audit
     check-cargo-makefile-syntax:
         name: Check cargo Makefile syntax is valid
@@ -117,3 +117,6 @@ jobs:
             - name: Check data-collector Makefile
               run: cargo make --print-steps 2>1& > /dev/null
               working-directory: data-collector/
+            - name: Check bundler-audit Makefile
+              run: cargo make --print-steps 2>&1 > /dev/null
+              working-directory: tool-images/ruby/bundler-audit

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -83,6 +83,18 @@ jobs:
             - name: Lint
               run: cargo clippy
               working-directory: kiln_lib/
+    build-data-collector-docker:
+        name: Build data-collector tool docker image
+        runs-on: ubuntu-18.04
+        steps:
+            - uses: davidB/rust-cargo-make@v1
+              with:
+                version: 0.22.2
+            - name: Checkout
+              uses: actions/checkout@v1
+            - name: Build data-collector
+              run: cargo make build-data-collector-master-docker
+              working-directory: data-collector
     build-bundler-audit-docker:
         name: Build Bundler-Audit tool docker image
         runs-on: ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ Kiln is still in it's early stages and isn't ready for production use. However, 
 - Open a PR and explain what changes you have made
 - Wait for CI to pass and PR to be reviewed
 - Merge!
+
+## Versioning
+Kiln follows [SemVer 2.0](https://semver.org/) for versioning and all components are versioned in lockstep.
+
+Our Docker images follow this naming convention:
+
+| /        | Master                                     | Release                             |
+| ---      | -------                                    | ---------                           |
+| Tool     | kiln/tool-name:master-GIT_SHA-TOOL_VERSION | kiln/tool-name:GIT_TAG-TOOL_VERSION |
+| Not Tool | kiln/component-name:master-GIT_SHA         | kiln/component-name:GIT_TAG         |
+
+The kiln/tool-name:master-latest, kiln/component-name:master-latest, kiln/tool-name:latest and kiln/component-name:latest are updated to point at the most recently published image for that channel.

--- a/data-collector/Makefile.toml
+++ b/data-collector/Makefile.toml
@@ -1,19 +1,23 @@
 [env]
 GIT_SHA = { script = ["git rev-parse --short HEAD"] }
-GIT_TAG = { script = ["git describe --tags --abbrev=0"] }
+GIT_BRANCH = { script = ["git rev-parse --abbrev-ref HEAD"] }
 
 [tasks.build-data-collector-docker]
 dependencies = [
     "clippy",
 	"test",
 	"musl-build",
-	"build-image",
+	"build-data-collector-docker-image",
 ]
 
 [tasks.musl-build]
 script = [
 	"docker run --rm -v $PWD:/workdir -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry registry.gitlab.com/rust_musl_docker/image:stable-latest cargo build --release --target=x86_64-unknown-linux-musl"
 ]
+
+[tasks.build-data-collector-docker-image]
+command = "docker"
+args = ["build", "-t", "kiln/data-collector:${GIT_BRANCH}-${GIT_SHA}", "."]
 
 [tasks.build-data-collector-master-docker]
 dependencies = ["build-data-collector-docker-tag-master-version", "build-data-collector-docker-tag-master-latest"]
@@ -30,9 +34,13 @@ args = ["tag", "kiln/data-collector:master-${GIT_SHA}", "kiln/data-collector:mas
 dependencies = ["build-data-collector-docker-tag-release-version", "build-data-collector-docker-tag-release-latest"]
 
 [tasks.build-data-collector-docker-tag-release-version]
-command = "docker"
-args = ["build", "-t", "kiln/data-collector:${GIT_TAG}", "."]
+script = [
+	"GIT_TAG=git rev-parse --abbrev-ref HEAD",
+	"docker build -t kiln/data-collector:$GIT_TAG ."
+]
 
 [tasks.build-data-collector-docker-tag-release-latest]
-command = "docker"
-args = ["tag", "kiln/data-collector:${GIT_TAG}", "kiln/data-collector:latest"]
+script = [
+	"GIT_TAG=git rev-parse --abbrev-ref HEAD",
+	"docker tag kiln/data-collector:$GIT_TAG kiln/data-collector:latest"
+]

--- a/data-collector/Makefile.toml
+++ b/data-collector/Makefile.toml
@@ -1,3 +1,7 @@
+[env]
+GIT_SHA = { script = ["git rev-parse --short HEAD"] }
+GIT_TAG = { script = ["git describe --tags --abbrev=0"] }
+
 [tasks.build-data-collector-docker]
 dependencies = [
     "clippy",
@@ -11,11 +15,24 @@ script = [
 	"docker run --rm -v $PWD:/workdir -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry registry.gitlab.com/rust_musl_docker/image:stable-latest cargo build --release --target=x86_64-unknown-linux-musl"
 ]
 
-[tasks.build-image]
+[tasks.build-data-collector-master-docker]
+dependencies = ["build-data-collector-docker-tag-master-version", "build-data-collector-docker-tag-master-latest"]
+
+[tasks.build-data-collector-docker-tag-master-version]
 command = "docker"
-args = [
-	"build",
-	"-t",
-	"kiln/data-collector:latest",
-	".",
-]
+args = ["build", "-t", "kiln/data-collector:master-${GIT_SHA}", "."]
+
+[tasks.build-data-collector-docker-tag-master-latest]
+command = "docker"
+args = ["tag", "kiln/data-collector:master-${GIT_SHA}", "kiln/data-collector:master-latest"]
+
+[tasks.build-data-collector-release-docker]
+dependencies = ["build-data-collector-docker-tag-release-version", "build-data-collector-docker-tag-release-latest"]
+
+[tasks.build-data-collector-docker-tag-release-version]
+command = "docker"
+args = ["build", "-t", "kiln/data-collector:${GIT_TAG}", "."]
+
+[tasks.build-data-collector-docker-tag-release-latest]
+command = "docker"
+args = ["tag", "kiln/data-collector:${GIT_TAG}", "kiln/data-collector:latest"]

--- a/tool-images/ruby/bundler-audit/Makefile.toml
+++ b/tool-images/ruby/bundler-audit/Makefile.toml
@@ -1,6 +1,6 @@
 [env]
 GIT_SHA = { script = ["git rev-parse --short HEAD"] }
-GIT_TAG = { script = ["git describe --tags --abbrev=0"] }
+GIT_BRANCH = { script = ["git rev-parse --abbrev-ref HEAD"] }
 TOOL_VERSION_BUNDLER_AUDIT="0.6.1"
 
 [tasks.pre-build-bundler-audit-docker]
@@ -10,6 +10,10 @@ args = ["../../../bin/data-forwarder", "data-forwarder"]
 [tasks.post-build-bundler-audit-docker]
 command = "rm"
 args = ["data-forwarder"]
+
+[tasks.build-bundler-audit-docker]
+command = "docker"
+args = ["build", "-t", "kiln/bundler-audit:${GIT_BRANCH}-${GIT_SHA}", "."]
 
 [tasks.build-bundler-audit-master-docker]
 dependencies = ["build-bundler-audit-docker-tag-master-version", "build-bundler-audit-docker-tag-master-latest"]
@@ -26,10 +30,13 @@ args = ["tag", "kiln/bundler-audit:master-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDI
 dependencies = ["build-bundler-audit-docker-tag-release-version", "build-bundler-audit-docker-tag-release-latest"]
 
 [tasks.build-bundler-audit-docker-tag-release-version]
-command = "docker"
-args = ["build", "-t", "kiln/bundler-audit:${GIT_TAG}-${TOOL_VERSION_BUNDLER_AUDIT}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
+script = [
+	"GIT_TAG=git rev-parse --abbrev-ref HEAD",
+	"docker build -t kiln/bundler-audit:$GIT_TAG-$TOOL_VERSION_BUNDLER_AUDIT --build-arg BUNDLER_AUDIT_VERSION=$TOOL_VERSION_BUNDLER_AUDIT ."
+]
 
 [tasks.build-bundler-audit-docker-tag-release-latest]
-command = "docker"
-args = ["tag", "kiln/bundler-audit:${GIT_TAG}-${TOOL_VERSION_BUNDLER_AUDIT}", "kiln/bundler-audit:latest"]
-
+script = [
+	"GIT_TAG=git rev-parse --abbrev-ref HEAD",
+	"docker tag kiln/bundler-audit:$GIT_TAG-$TOOL_VERSION_BUNDLER_AUDIT kiln/bundler-audit:latest"
+]

--- a/tool-images/ruby/bundler-audit/Makefile.toml
+++ b/tool-images/ruby/bundler-audit/Makefile.toml
@@ -1,4 +1,6 @@
 [env]
+GIT_SHA = { script = ["git rev-parse --short HEAD"] }
+GIT_TAG = { script = ["git describe --tags --abbrev=0"] }
 TOOL_VERSION_BUNDLER_AUDIT="0.6.1"
 
 [tasks.pre-build-bundler-audit-docker]
@@ -9,14 +11,25 @@ args = ["../../../bin/data-forwarder", "data-forwarder"]
 command = "rm"
 args = ["data-forwarder"]
 
-[tasks.build-bundler-audit-docker]
-dependencies = ["build-bundler-audit-docker-tag-version", "build-bundler-audit-docker-tag-latest"]
+[tasks.build-bundler-audit-master-docker]
+dependencies = ["build-bundler-audit-docker-tag-master-version", "build-bundler-audit-docker-tag-master-latest"]
 
-[tasks.build-bundler-audit-docker-tag-version]
+[tasks.build-bundler-audit-docker-tag-master-version]
 command = "docker"
-args = ["build", "-t", "kiln/bundler-audit:${TOOL_VERSION_BUNDLER_AUDIT}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
+args = ["build", "-t", "kiln/bundler-audit:master-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
 
-[tasks.build-bundler-audit-docker-tag-latest]
+[tasks.build-bundler-audit-docker-tag-master-latest]
 command = "docker"
-args = ["tag", "kiln/bundler-audit:${TOOL_VERSION_BUNDLER_AUDIT}", "kiln/bundler-audit:latest"]
+args = ["tag", "kiln/bundler-audit:master-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}", "kiln/bundler-audit:master-latest"]
+
+[tasks.build-bundler-audit-release-docker]
+dependencies = ["build-bundler-audit-docker-tag-release-version", "build-bundler-audit-docker-tag-release-latest"]
+
+[tasks.build-bundler-audit-docker-tag-release-version]
+command = "docker"
+args = ["build", "-t", "kiln/bundler-audit:${GIT_TAG}-${TOOL_VERSION_BUNDLER_AUDIT}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
+
+[tasks.build-bundler-audit-docker-tag-release-latest]
+command = "docker"
+args = ["tag", "kiln/bundler-audit:${GIT_TAG}-${TOOL_VERSION_BUNDLER_AUDIT}", "kiln/bundler-audit:latest"]
 


### PR DESCRIPTION
# What does this PR change?
- Updates the docker image naming format to make it clear which builds are from master and which are tagged releases
- Adds Makefile target for Data collector and bundler audit images for master and release builds
- Adds missing CI for Data-collector docker image

# Why is it important?
- Required for #44 

# Checklist
- [ ] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
