### PR TITLE
Tool: Fix bug #86 in Bundler Audit docker image to support Bundler 2.

### DIFF
--- a/tool-images/ruby/bundler-audit/Dockerfile
+++ b/tool-images/ruby/bundler-audit/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:2-alpine
 RUN apk --no-cache add git
+RUN gem install bundler
 WORKDIR /code
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
# What does this PR change?
* Installs bundler 2 as part of image build

# Why is it important?
* Allows container to be used with codebases using bundler 1 or bundler 2.
* Fixed #86 

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
