### PR TITLE
Kiln_lib: Make parts of crate optional using features and conditional compilation

### DIFF
--- a/kiln_lib/Cargo.toml
+++ b/kiln_lib/Cargo.toml
@@ -4,11 +4,19 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-avro-rs = "0.6"
+avro-rs = { version = "0.6", optional = true }
 chrono = { version = "0.4", features = ["serde"] }
-actix-web = "1.0"
-http = "0.1"
-serde_json = "1.0"
+actix-web = { version = "1.0", optional = true }
+http = { version = "0.1", optional = true }
+serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 regex = "1.0"
 failure = "0.1"
+
+[features]
+
+default = []
+all = ["avro", "web"]
+avro = ["avro-rs"]
+json = ["serde_json"]
+web = ["actix-web", "http", "json"]

--- a/kiln_lib/README.md
+++ b/kiln_lib/README.md
@@ -1,5 +1,12 @@
 # Kiln-lib
 
+## Features
+This crates makes use of Cargo features and conditional compilation to allow consuming crates to only turn on the features they need, reducing compilation times in most cases. When making changes to Kiln_lib itself, you need to be mindful of whether your change should be behind an optional feature and that tests need to be run with ALL features turned on. An easy way to achieve this is by running `cargo make test` which enables all features by default.
+
+- JSON: Enables the serde_json crate and parsing values from JSON and serialising to JSON
+- Web: Enables the Actix-web and HTTP crates, as well as the JSON feature
+- Avro: Enables the avro-rs crate and allows serialising and deserialising Avro values
+
 ## Avro Schema
 In Kiln, messages are serialised to the [Apache Avro format](https://avro.apache.org/docs/current/) before being sent to an Apache Kafka topic to be recorded. Below is the schema used to encode messages in Avro. Note that every field is recorded as a string. This is intentional, because all data validation should happen by building an instance of the ToolReport struct, either from JSON values in the case of the data-collector, or from string using the TryFrom<String> implementations for fields in the structy directly for other components. This scheme is validated using a test that parses the schema, so any invalid changes should be caught by CI.
 

--- a/kiln_lib/src/lib.rs
+++ b/kiln_lib/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "avro")]
 pub mod avro_schema {
     pub const TOOL_REPORT_SCHEMA: &str = r#"
         {
@@ -31,7 +32,6 @@ pub mod avro_schema {
 }
 
 pub mod validation {
-    use actix_web::HttpResponse;
     use serde::Serialize;
     use std::error::Error; 
     use std::fmt; 
@@ -325,6 +325,10 @@ pub mod validation {
         }
     }
 
+    #[cfg(feature = "web")]
+    use actix_web::HttpResponse;
+
+    #[cfg(feature = "web")]
     impl Into<HttpResponse> for ValidationError {
         fn into(self) -> HttpResponse {
             HttpResponse::BadRequest()
@@ -334,17 +338,23 @@ pub mod validation {
 }
 
 pub mod tool_report {
+    #[cfg(feature = "avro")]
     use crate::avro_schema::TOOL_REPORT_SCHEMA;
+    #[cfg(feature = "avro")]
+    use avro_rs::schema::Schema;
+    #[cfg(feature = "avro")]
+    use avro_rs::types::{Record, ToAvro};
+
+    #[cfg(feature = "json")]
+    use serde_json::value::Value;
+
     use crate::validation::ValidationError;
 
     use std::convert::TryFrom;
 
-    use avro_rs::schema::Schema;
-    use avro_rs::types::{Record, ToAvro};
     use chrono::{DateTime, Utc};
     use failure::err_msg;
     use regex::Regex;
-    use serde_json::value::Value;
     use serde::Serialize;
 
     #[allow(dead_code)]
@@ -581,7 +591,8 @@ pub mod tool_report {
             }
         }
     }
-
+    
+    #[cfg(feature = "json")]
     impl TryFrom<&Value> for ToolReport {
         type Error = ValidationError;
 
@@ -611,6 +622,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "avro")]
     impl<'a> TryFrom<avro_rs::types::Value> for ToolReport {
         type Error = failure::Error;
 
@@ -686,7 +698,8 @@ pub mod tool_report {
             }
         }
     }
-
+    
+    #[cfg(feature = "avro")]
     impl TryFrom<avro_rs::types::Value> for ApplicationName {
         type Error = ValidationError;
 
@@ -698,6 +711,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "avro")]
     impl TryFrom<avro_rs::types::Value> for GitBranch {
         type Error = ValidationError;
 
@@ -710,6 +724,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "avro")]
     impl TryFrom<avro_rs::types::Value> for GitCommitHash {
         type Error = ValidationError;
 
@@ -721,6 +736,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "avro")]
     impl TryFrom<avro_rs::types::Value> for ToolName {
         type Error = ValidationError;
 
@@ -732,6 +748,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "avro")]
     impl TryFrom<avro_rs::types::Value> for ToolOutput {
         type Error = ValidationError;
 
@@ -743,6 +760,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "avro")]
     impl TryFrom<avro_rs::types::Value> for OutputFormat {
         type Error = ValidationError;
 
@@ -760,6 +778,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "avro")]
     impl TryFrom<avro_rs::types::Value> for StartTime {
         type Error = ValidationError;
 
@@ -773,6 +792,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "avro")]
     impl TryFrom<avro_rs::types::Value> for EndTime {
         type Error = ValidationError;
 
@@ -799,6 +819,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "avro")]
     impl TryFrom<avro_rs::types::Value> for Environment {
         type Error = ValidationError;
 
@@ -812,6 +833,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "avro")]
     impl TryFrom<avro_rs::types::Value> for ToolVersion {
         type Error = ValidationError;
 
@@ -824,6 +846,7 @@ pub mod tool_report {
         }
     }
 
+    #[cfg(feature = "json")]
     impl ToolReport {
         fn parse_application_name(json_value: &Value) -> Result<ApplicationName, ValidationError> {
             let value = match &json_value["application_name"] {
@@ -932,13 +955,15 @@ pub mod tool_report {
     }
 
     #[cfg(test)]
+    #[cfg(feature = "all")]
     pub mod tests {
         // TODO: Separate tests based on whether they test the JSON validation or the business logic
         // validation
         use super::*;
+
         use avro_rs::{Reader, Schema, Writer};
 
-        pub mod tool_report {
+        pub mod tool_report_json {
             use super::*;
 
             #[test]


### PR DESCRIPTION
# What does this PR change?
- Adds the web, json and avro features to kiln_lib, so consuming crates can turn on only the features they need

# Why is it important?
- Reduces compilation times

# Checklist
- [ ] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
