### PR TITLE
CI speed up

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -26,8 +26,8 @@ jobs:
               with:
                 path: data-collector/target
                 key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('data-collector/Cargo.lock') }}
-            - name: Build data-collector docker image
-              run: cargo make build-data-collector-docker
+            - name: Build
+              run: cargo make build-data-collector
     data-forwarder:
         name: Data-forwarder build
         runs-on: ubuntu-18.04
@@ -54,11 +54,6 @@ jobs:
                 key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('data-forwarder/Cargo.lock') }}
             - name: Build data-forwarder
               run: cargo make build-data-forwarder
-            - name: Upload data-forwarder
-              uses: actions/upload-artifact@v1
-              with:
-                name: data-forwarder
-                path: bin/data-forwarder
     kiln_lib:
         name: Kiln_lib build
         runs-on: ubuntu-18.04
@@ -89,24 +84,6 @@ jobs:
             - name: Lint
               run: cargo clippy --all-features
               working-directory: kiln_lib/
-    build-bundler-audit-docker:
-        name: Build Bundler-Audit tool docker image
-        runs-on: ubuntu-18.04
-        needs: data-forwarder
-        steps:
-            - uses: davidB/rust-cargo-make@v1
-              with:
-                version: 0.22.2
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Download pre-built data-forwarder
-              uses: actions/download-artifact@v1
-              with:
-                name: data-forwarder
-                path: tool-images/ruby/bundler-audit/
-            - name: Build bundler-audit
-              run: cargo make build-bundler-audit-master-docker
-              working-directory: tool-images/ruby/bundler-audit
     check-cargo-makefile-syntax:
         name: Check cargo Makefile syntax is valid
         runs-on: ubuntu-18.04

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -65,9 +65,6 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v1
-            - name: Build
-              run: cargo build --all-features
-              working-directory: kiln_lib/
             - name: Cache cargo registry
               uses: actions/cache@v1
               with:
@@ -83,6 +80,9 @@ jobs:
               with:
                 path: kiln_lib/target
                 key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('kiln_lib/Cargo.lock') }}
+            - name: Build
+              run: cargo build --all-features
+              working-directory: kiln_lib/
             - name: Test
               run: cargo test --all-features
               working-directory: kiln_lib/

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -2,61 +2,35 @@ name: CI
 on: [push]
 
 jobs:
-    build-data-collector:
+    data-collector:
         name: Data-collector build
         runs-on: ubuntu-18.04
         steps:
             - name: Checkout
               uses: actions/checkout@v1
-            - name: Build
-              run: cargo build
-              working-directory: data-collector/
-    test-data-collector:
-        name: Data-collector tests
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Test
-              run: cargo test
-              working-directory: data-collector/
-    lint-data-collector:
-        name: Data-collector lint
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Lint
-              run: cargo clippy
-              working-directory: data-collector/
-    build-data-forwarder:
+            - uses: davidB/rust-cargo-make@v1
+              with:
+                version: 0.22.2
+            - name: Build data-collector docker image
+              run: cargo make build-data-collector-docker-image
+              working-directory: data-collector
+    data-forwarder:
         name: Data-forwarder build
         runs-on: ubuntu-18.04
         steps:
             - name: Checkout
               uses: actions/checkout@v1
-            - name: Build
-              run: cargo build
-              working-directory: data-forwarder/
-    test-data-forwarder:
-        name: Data-forwarder tests
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Test
-              run: cargo test
-              working-directory: data-forwarder/
-    lint-data-forwarder:
-        name: Data-forwarder lint
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Lint
-              run: cargo clippy
-              working-directory: data-forwarder/
-    build-kiln_lib:
+            - uses: davidB/rust-cargo-make@v1
+              with:
+                version: 0.22.2
+            - name: Build data-forwarder
+              run: cargo make build-data-forwarder
+            - name: Upload data-forwarder
+              uses: actions/upload-artifact@v1
+              with:
+                name: data-forwarder
+                path: bin/data-forwarder
+    kiln_lib:
         name: Kiln_lib build
         runs-on: ubuntu-18.04
         steps:
@@ -65,53 +39,27 @@ jobs:
             - name: Build
               run: cargo build
               working-directory: kiln_lib/
-    test-kiln-lib:
-        name: Kiln_lib tests
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
             - name: Test
               run: cargo test
               working-directory: kiln_lib/
-    lint-kiln-lib:
-        name: Kiln_lib lint
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
             - name: Lint
               run: cargo clippy
               working-directory: kiln_lib/
-    build-data-collector-docker:
-        name: Build data-collector tool docker image
-        runs-on: ubuntu-18.04
-        steps:
-            - uses: davidB/rust-cargo-make@v1
-              with:
-                version: 0.22.2
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Build data-collector for musl-libc
-              run: cargo make musl-build
-              working-directory: data-collector
-            - name: Build data-collector docker image
-              run: cargo make build-data-collector-docker-image
-              working-directory: data-collector
     build-bundler-audit-docker:
         name: Build Bundler-Audit tool docker image
         runs-on: ubuntu-18.04
+        needs: data-forwarder
         steps:
             - uses: davidB/rust-cargo-make@v1
               with:
                 version: 0.22.2
             - name: Checkout
               uses: actions/checkout@v1
-            - name: Build data-forwarder
-              run: cargo make build-data-forwarder
-            - name: Pre-build bundler-audit
-              run: cargo make pre-build-bundler-audit-docker
-              working-directory: tool-images/ruby/bundler-audit
+            - name: Download pre-built data-forwarder
+              uses: actions/download-artifact@v1
+              with:
+                name: data-forwarder
+                path: tool-images/ruby/bundler-audit/
             - name: Build bundler-audit
               run: cargo make build-bundler-audit-master-docker
               working-directory: tool-images/ruby/bundler-audit
@@ -119,10 +67,6 @@ jobs:
         name: Check cargo Makefile syntax is valid
         runs-on: ubuntu-18.04
         steps:
-            - uses: actions-rs/toolchain@v1
-              with:
-                toolchain: stable
-                override: true
             - uses: davidB/rust-cargo-make@v1
               with:
                 version: 0.22.2
@@ -135,3 +79,6 @@ jobs:
             - name: Check bundler-audit Makefile
               run: cargo make --print-steps 2>&1 > /dev/null
               working-directory: tool-images/ruby/bundler-audit
+            - name: Check datra-forwarder Makefile
+              run: cargo make --print-steps 2>&1 > /dev/null
+              working-directory: data-forwarder

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -12,8 +12,7 @@ jobs:
               with:
                 version: 0.22.2
             - name: Build data-collector docker image
-              run: cargo make build-data-collector-docker-image
-              working-directory: data-collector
+              run: cargo make build-data-collector-docker
     data-forwarder:
         name: Data-forwarder build
         runs-on: ubuntu-18.04

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -36,13 +36,13 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v1
             - name: Build
-              run: cargo build
+              run: cargo build --all-features
               working-directory: kiln_lib/
             - name: Test
-              run: cargo test
+              run: cargo test --all-features
               working-directory: kiln_lib/
             - name: Lint
-              run: cargo clippy
+              run: cargo clippy --all-features
               working-directory: kiln_lib/
     build-bundler-audit-docker:
         name: Build Bundler-Audit tool docker image

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -11,6 +11,21 @@ jobs:
             - uses: davidB/rust-cargo-make@v1
               with:
                 version: 0.22.2
+            - name: Cache cargo registry
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/registry
+                key: ${{ runner.os }}-cargo-registry-${{ hashFiles('data-collector/Cargo.lock') }}
+            - name: Cache cargo index
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/git
+                key: ${{ runner.os }}-cargo-index-${{ hashFiles('data-collector/Cargo.lock') }}
+            - name: Cache cargo build
+              uses: actions/cache@v1
+              with:
+                path: data-collector/target
+                key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('data-collector/Cargo.lock') }}
             - name: Build data-collector docker image
               run: cargo make build-data-collector-docker
     data-forwarder:
@@ -22,6 +37,21 @@ jobs:
             - uses: davidB/rust-cargo-make@v1
               with:
                 version: 0.22.2
+            - name: Cache cargo registry
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/registry
+                key: ${{ runner.os }}-cargo-registry-${{ hashFiles('data-forwarder/Cargo.lock') }}
+            - name: Cache cargo index
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/git
+                key: ${{ runner.os }}-cargo-index-${{ hashFiles('data-forwarder/Cargo.lock') }}
+            - name: Cache cargo build
+              uses: actions/cache@v1
+              with:
+                path: data-forwarder/target
+                key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('data-forwarder/Cargo.lock') }}
             - name: Build data-forwarder
               run: cargo make build-data-forwarder
             - name: Upload data-forwarder
@@ -38,6 +68,21 @@ jobs:
             - name: Build
               run: cargo build --all-features
               working-directory: kiln_lib/
+            - name: Cache cargo registry
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/registry
+                key: ${{ runner.os }}-cargo-registry-${{ hashFiles('kiln_lib/Cargo.lock') }}
+            - name: Cache cargo index
+              uses: actions/cache@v1
+              with:
+                path: ~/.cargo/git
+                key: ${{ runner.os }}-cargo-index-${{ hashFiles('kiln_lib/Cargo.lock') }}
+            - name: Cache cargo build
+              uses: actions/cache@v1
+              with:
+                path: kiln_lib/target
+                key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('kiln_lib/Cargo.lock') }}
             - name: Test
               run: cargo test --all-features
               working-directory: kiln_lib/

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -123,6 +123,6 @@ jobs:
             - name: Check bundler-audit Makefile
               run: cargo make --print-steps 2>&1 > /dev/null
               working-directory: tool-images/ruby/bundler-audit
-            - name: Check datra-forwarder Makefile
+            - name: Check data-forwarder Makefile
               run: cargo make --print-steps 2>&1 > /dev/null
               working-directory: data-forwarder

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,6 +28,7 @@ jobs:
                 key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('data-collector/Cargo.lock') }}
             - name: Build
               run: cargo make build-data-collector
+              working-directory: data-collector/
     data-forwarder:
         name: Data-forwarder build
         runs-on: ubuntu-18.04
@@ -54,6 +55,7 @@ jobs:
                 key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('data-forwarder/Cargo.lock') }}
             - name: Build data-forwarder
               run: cargo make build-data-forwarder
+              working-directory: data-forwarder/
     kiln_lib:
         name: Kiln_lib build
         runs-on: ubuntu-18.04

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,7 +1,7 @@
 [tasks.build-docker-images]
 dependencies = [
     "build-data-collector-docker",
-	"build-data-forwarder",
+	"build-data-forwarder-musl",
 	"build-bundler-audit-docker"
 ]
 
@@ -9,9 +9,9 @@ dependencies = [
 command = "cargo"
 args = ["make", "--cwd", "data-collector", "build-data-collector-docker"]
 
-[tasks.build-data-forwarder]
+[tasks.build-data-forwarder-musl]
 command = "cargo"
-args = ["make", "--cwd", "data-forwarder", "build-data-forwarder"]
+args = ["make", "--cwd", "data-forwarder", "build-data-forwarder-musl"]
 
 [tasks.build-bundler-audit-docker]
 command = "cargo"

--- a/data-collector/Cargo.toml
+++ b/data-collector/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4"
-actix-web = "1.0"
+actix-web = { version = "1.0", features = ["fail"] }
 bytes = "0.4"
 futures = "0.1"
 http = "0.1"

--- a/data-collector/Makefile.toml
+++ b/data-collector/Makefile.toml
@@ -2,10 +2,15 @@
 GIT_SHA = { script = ["git rev-parse --short HEAD"] }
 GIT_BRANCH = { script = ["git rev-parse --abbrev-ref HEAD"] }
 
-[tasks.build-data-collector-docker]
+[tasks.build-data-collector]
 dependencies = [
     "clippy",
 	"test",
+	"build",
+]
+
+[tasks.build-data-collector-docker]
+dependencies = [
 	"musl-build",
 	"build-data-collector-docker-image",
 ]

--- a/data-forwarder/Makefile.toml
+++ b/data-forwarder/Makefile.toml
@@ -1,7 +1,6 @@
 [tasks.build-data-forwarder]
 dependencies = [
     "clippy",
-	"test",
 	"musl-build", 
 	"copy-binary-to-root-dir",
 ]

--- a/data-forwarder/Makefile.toml
+++ b/data-forwarder/Makefile.toml
@@ -1,6 +1,11 @@
 [tasks.build-data-forwarder]
 dependencies = [
+	"build",
     "clippy",
+]
+
+[tasks.build-data-forwarder-musl]
+dependencies = [
 	"musl-build", 
 	"copy-binary-to-root-dir",
 ]

--- a/tool-images/ruby/bundler-audit/Makefile.toml
+++ b/tool-images/ruby/bundler-audit/Makefile.toml
@@ -13,7 +13,7 @@ args = ["data-forwarder"]
 
 [tasks.build-bundler-audit-docker]
 command = "docker"
-args = ["build", "-t", "kiln/bundler-audit:${GIT_BRANCH}-${GIT_SHA}", "."]
+args = ["build", "-t", "kiln/bundler-audit:${GIT_BRANCH}-${GIT_SHA}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
 
 [tasks.build-bundler-audit-master-docker]
 dependencies = ["build-bundler-audit-docker-tag-master-version", "build-bundler-audit-docker-tag-master-latest"]


### PR DESCRIPTION
# What does this PR change?

- Collapses component builds into a single job per component to avoid duplicating work
- Removes steps that aren't needed for CI
- Output caching between builds based on hash of Cargo.lock for each component
- Remove building of Docker images for CI, will only build on merge to master (future work)
- Introduce features and optional dependencies for Kiln_lib, so that consuming crates don't need to build code and dependencies they don't use

# Why is it important?

- Makes feedback on changes much quicker

# Checklist
- [ ] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
