### PR TITLE
CI: Use a docker login step that actually exists

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -32,10 +32,10 @@ jobs:
             - name: Build
               run: cargo make build-data-collector-docker
             - name: docker login
-              uses: actions/docker/login@master
-              env:
-                DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-                DOCKER_USERNAME: kilnautomation
+              uses: azure/docker-login@v1
+              with:
+                password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+                username: kilnautomation
             - name: Docker push version
               run: cargo make data-collector-push-master-version
             - name: Docker push latest
@@ -90,10 +90,10 @@ jobs:
               run: cargo make build-bundler-audit-master-docker
               working-directory: tool-images/ruby/bundler-audit
             - name: docker login
-              uses: actions/docker/login@master
-              env:
-                DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-                DOCKER_USERNAME: kilnautomation
+              uses: azure/docker-login@v1
+              with:
+                password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+                username: kilnautomation
             - name: Docker push version
               run: cargo make bundler-audit-push-master-version
             - name: Docker push latest


### PR DESCRIPTION
# What does this PR change?

- Fixes the docker login step for building images on a merge to master

# Why is it important?

- Needed for #44

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
