### PR TITLE
CI: Fix build target for data-forwarder when building docker images on master

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -65,7 +65,8 @@ jobs:
                 path: data-forwarder/target
                 key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('data-forwarder/Cargo.lock') }}
             - name: Build data-forwarder
-              run: cargo make build-data-forwarder
+              run: cargo make build-data-forwarder-musl
+              working-directory: data-forwarder/
             - name: Upload data-forwarder
               uses: actions/upload-artifact@v1
               with:


### PR DESCRIPTION
# What does this PR change?

- Changes the build target used for the data-forwarder binary when building docker images on master

# Why is it important?

- Fixes CI required for #44

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
