### PR TITLE
CI: Add missing working-directory directives to build-docker-image CI so build targets can be found

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -31,6 +31,7 @@ jobs:
                 key: ${{ runner.os }}-cargo-build-target-musl-${{ hashFiles('data-collector/Cargo.lock') }}
             - name: Build
               run: cargo make build-data-collector-docker
+              working-directory: data-collector/
             - name: docker login
               uses: azure/docker-login@v1
               with:
@@ -38,8 +39,10 @@ jobs:
                 username: kilnautomation
             - name: Docker push version
               run: cargo make data-collector-push-master-version
+              working-directory: data-collector/
             - name: Docker push latest
               run: cargo make data-collector-push-master-latest
+              working-directory: data-collector/
     data-forwarder:
         name: Data-forwarder build
         runs-on: ubuntu-18.04
@@ -97,5 +100,7 @@ jobs:
                 username: kilnautomation
             - name: Docker push version
               run: cargo make bundler-audit-push-master-version
+              working-directory: tool-images/ruby/bundler-audit
             - name: Docker push latest
               run: cargo make bundler-audit-push-master-latest
+              working-directory: tool-images/ruby/bundler-audit


### PR DESCRIPTION
#What does this PR change?

- Adds working directories in master push CI

# Why is it important?

- Fixes build needed for #44

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
