### PR TITLE
CI: Fix docker image build for data-collector when pushing to master

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -30,7 +30,7 @@ jobs:
                 path: data-collector/target
                 key: ${{ runner.os }}-cargo-build-target-musl-${{ hashFiles('data-collector/Cargo.lock') }}
             - name: Build
-              run: cargo make build-data-collector-docker
+              run: cargo make build-data-collector-master-docker
               working-directory: data-collector/
             - name: docker login
               uses: azure/docker-login@v1

--- a/data-collector/Makefile.toml
+++ b/data-collector/Makefile.toml
@@ -25,7 +25,7 @@ command = "docker"
 args = ["build", "-t", "kiln/data-collector:${GIT_BRANCH}-${GIT_SHA}", "."]
 
 [tasks.build-data-collector-master-docker]
-dependencies = ["build-data-collector-docker-tag-master-version", "build-data-collector-docker-tag-master-latest"]
+dependencies = ["musl-build", "build-data-collector-docker-tag-master-version", "build-data-collector-docker-tag-master-latest"]
 
 [tasks.build-data-collector-docker-tag-master-version]
 command = "docker"
@@ -44,7 +44,7 @@ command = "docker"
 args = ["push", "kiln/data-collector:master-latest"]
 
 [tasks.build-data-collector-release-docker]
-dependencies = ["build-data-collector-docker-tag-release-version", "build-data-collector-docker-tag-release-latest"]
+dependencies = ["musl-build", "build-data-collector-docker-tag-release-version", "build-data-collector-docker-tag-release-latest"]
 
 [tasks.build-data-collector-docker-tag-release-version]
 script = [


### PR DESCRIPTION
# What does this PR change?

- Switches the master push docker image build workflow to use the data-collector build target that tags images as being built from master

# Why is it important?

- Fixes docker image builds on master

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
