### PR TITLE
Bundler-audit: Update entrypoint script to cleanup tool output text file after it is not needed, fixed #106.

### DIFF
--- a/tool-images/ruby/bundler-audit/entrypoint.sh
+++ b/tool-images/ruby/bundler-audit/entrypoint.sh
@@ -4,3 +4,5 @@ bundle audit check --update | tee tool-output.txt
 END_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
 
 /data-forwarder --tool-name=bundler-audit --tool-version=0.6.1 --tool-output-path=tool-output.txt --start-time="$START_TIME" --end-time="$END_TIME" --output-format=PlainText --scan-env="$SCAN_ENV" --app-name="$APP_NAME" --endpoint-url="$DATA_COLLECTOR_URL"
+
+rm tool-output.txt


### PR DESCRIPTION
# What does this PR change?

- Update entrypoint script to cleanup tool output text file after it is not needed

# Why is it important?

- Fixes #106 

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
