### PR TITLE
Adopt event schema changes

### DIFF
--- a/data-collector/Cargo.lock
+++ b/data-collector/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "kiln_lib"
 version = "0.1.0"
-source = "git+https://github.com/simplybusiness/Kiln#4ef6091ef89970f200c86c114d00d02036d6034c"
+source = "git+https://github.com/simplybusiness/Kiln#1c88fc580f97d7085733cf200cf518ac733c9e71"
 dependencies = [
  "actix-web 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "avro-rs 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -817,6 +817,7 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1882,6 +1883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,6 +2182,7 @@ dependencies = [
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
+"checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"

--- a/data-collector/docs/request-response.md
+++ b/data-collector/docs/request-response.md
@@ -3,6 +3,8 @@ This service has a single endpoint, exposed behind an AWS API gateway.
 Requests to this endpoint must be in JSON format in the following format:
 ```
 {
+        event_version: String(always "1"),
+        event_id: UUIDv4,
         application_name: String,
         git_branch: String,
         git_commit_hash: String,

--- a/data-collector/src/main.rs
+++ b/data-collector/src/main.rs
@@ -201,7 +201,7 @@ mod tests {
     use serial_test_derive::serial;
 
     use kiln_lib::tool_report::{
-        ApplicationName, EndTime, Environment, GitBranch, GitCommitHash, OutputFormat, StartTime,
+        ApplicationName, EndTime, Environment, EventID, EventVersion, GitBranch, GitCommitHash, OutputFormat, StartTime,
         ToolName, ToolOutput, ToolVersion,
     };
 
@@ -250,6 +250,8 @@ mod tests {
     #[test]
     fn parse_payload_returns_tool_report_when_request_valid() {
         let p = r#"{
+                    "event_version": "1",
+                    "event_id": "95130bee-95ae-4dac-aecf-5650ff646ea1",
                     "application_name": "Test application",
                     "git_branch": "master",
                     "git_commit_hash": "e99f715d0fe787cd43de967b8a79b56960fed3e5",
@@ -267,6 +269,8 @@ mod tests {
         body.extend_from_slice(payload);
 
         let expected = ToolReport {
+            event_version: EventVersion::try_from("1".to_owned()).unwrap(),
+            event_id: EventID::try_from("95130bee-95ae-4dac-aecf-5650ff646ea1".to_owned()).unwrap(),
             application_name: ApplicationName::try_from("Test application".to_owned()).unwrap(),
             git_branch: GitBranch::try_from(Some("master".to_owned())).unwrap(),
             git_commit_hash: GitCommitHash::try_from(

--- a/data-forwarder/Cargo.lock
+++ b/data-forwarder/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kiln_lib 0.1.0 (git+https://github.com/simplybusiness/Kiln)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -526,13 +527,14 @@ dependencies = [
 [[package]]
 name = "kiln_lib"
 version = "0.1.0"
-source = "git+https://github.com/simplybusiness/Kiln#4ef6091ef89970f200c86c114d00d02036d6034c"
+source = "git+https://github.com/simplybusiness/Kiln#1c88fc580f97d7085733cf200cf518ac733c9e71"
 dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1408,6 +1410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1653,7 @@ dependencies = [
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
+"checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/data-forwarder/Cargo.toml
+++ b/data-forwarder/Cargo.toml
@@ -9,3 +9,4 @@ clap = "2"
 chrono = "0.4"
 reqwest = "0.9" 
 git2 = "0.10"
+uuid = { version = "0.8", features = ["v4"] }

--- a/data-forwarder/src/main.rs
+++ b/data-forwarder/src/main.rs
@@ -1,4 +1,4 @@
-use kiln_lib::tool_report::{ToolReport, ApplicationName, GitBranch, GitCommitHash,  ToolName, ToolOutput, OutputFormat,StartTime,EndTime,Environment,ToolVersion}; 
+use kiln_lib::tool_report::{ToolReport, ApplicationName, GitBranch, GitCommitHash,  ToolName, ToolOutput, OutputFormat, EventVersion, EventID, Environment,ToolVersion}; 
 use kiln_lib::validation::ValidationError; 
 use clap::{Arg, App}; 
 use std::convert::TryFrom; 
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::io::prelude::*;
 use std::env;
 use git2::Repository;
+use uuid::Uuid;
 
 fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
     let matches = App::new("Kiln data forwarder")
@@ -112,6 +113,8 @@ fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         let git_commit = head.peel_to_commit()?.id().to_string(); 
 
 	let tool_report = ToolReport { 
+                event_version: EventVersion::try_from("1".to_string())?,
+                event_id: EventID::try_from(Uuid::new_v4().to_hyphenated().to_string())?,
 		application_name: ApplicationName::try_from(app_name.to_string())?, 
 		git_branch: GitBranch::try_from(git_branch_name)?, 
 		git_commit_hash: GitCommitHash::try_from(git_commit)?, 


### PR DESCRIPTION
# What does this PR change?

- Adopts changes from kiln_lib that add an event_version field and event_id field to tool reports

# Why is it important?

- Allows us to trace a derived event to it's parent
- Allows us to evolve the schema of ToolReports over time

# Checklist
- [x] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
