### PR TITLE
Bundler-audit: Ensured that container now have both bundler 1.17.3 and bundler 2

### DIFF
--- a/tool-images/ruby/bundler-audit/Dockerfile
+++ b/tool-images/ruby/bundler-audit/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2-alpine
 RUN apk --no-cache add git
-RUN gem install bundler
+RUN gem install bundler -v "~>1.0" && \
+    gem install bundler -v "~>2.0"
 WORKDIR /code
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
# What does this PR change?
- Updated Bundler-audit Dockerfile to install both major versions of Bundler gem

# Why is it important?
- Compatibility with both old and new versions of Bundler used by projects

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
