### PR TITLE
Docs: Update release docs to remove windows binary build and include artifact signing

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -98,6 +98,6 @@ Once you have completed these steps, Github Actions will trigger the release wor
 * Ensure GPG installed
 * Import release public keys from `meta/release-keys`
 * Verify signature on the release tag to ensure it was created by a trusted releaser
-* Zip contents of repo and upload to Github Releases
-* Build CLI app on Windows, Linux and MacOS and upload to Github Releases
+* Archive contents of repo and upload to Github Releases, compute hash of archive and upload to Github Releases, make detached signature of hash and upload to Github Releases
+* Build CLI app on Linux and MacOS and upload to Github Releases, compute hash of binaries and upload to Github Releases, make detached signature of hash and upload to Github Releases
 * Build all docker images with latest, datestamp and SemVer tags (including the version of tools where appropriate) and push to Docker Hub


### PR DESCRIPTION
#What does this PR change?
- Updates release docs to remove Windows build step
- Updates release docs to include artifact signing for CLI app and repo tarball

# Why is it important?
- Keeps documentation up to date with plans in #44 

# Checklist
- [ ] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
