### PR TITLE
Fix references to old naming convention

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   data-collector:
     depends_on: 
       - kafka
-    image: kiln/data-collector:latest
+    image: kiln/data-collector:master-latest
     ports:
       - "8081:8080"
     environment:

--- a/docs/integration_testing.md
+++ b/docs/integration_testing.md
@@ -52,6 +52,8 @@ Below are a valid JSON payload for a request to the data-collector and an exampl
 
 ```
 {
+    "event_version": "1",
+    "event_id": "123e4567-e89b-12d3-a456-426655440000",
     "application_name": "Test application",
     "git_branch": "master",
     "git_commit_hash": "e99f715d0fe787cd43de967b8a79b56960fed3e5",
@@ -77,6 +79,8 @@ curl -X POST \
   -H 'Host: 127.0.0.1:8081' \
   -H 'cache-control: no-cache' \
   -d '{
+    "event_version": "1",
+    "event_id": "123e4567-e89b-12d3-a456-426655440000",
     "application_name": "Test application",
     "git_branch": "master",
     "git_commit_hash": "e99f715d0fe787cd43de967b8a79b56960fed3e5",

--- a/docs/integration_testing.md
+++ b/docs/integration_testing.md
@@ -9,19 +9,19 @@ Currently, there is no automated integration testing of Kiln, but it is possible
 Parts of this process have been automated using Cargo-make, which is the task runner for the Kiln build process.
 
 ## Building the Data-forwarder binary for musl-libc
-There is a Cargo-make target for building this component for musl-libc which will also run linting and unit tests. `cd` to the project root directory and run `cargo make build-data-forwarder`.
+There is a Cargo-make target for building this component for musl-libc which will also run linting and unit tests. `cd` to the project root directory and run `cargo make build-data-forwarder-musl`.
 
 ## Building the tool docker image
 This step assumes you have already built the Data-forwarder using the previously mentioned Cargo-make target. The Bundler-audit `Makefile.toml` includes a set of tasks that can be used as a starting point for building new tool images. `cd` to the directory containing your tool image, then run:
 ```
 cargo make pre-build-bundler-audit-docker
-cargo make build-bundler-audit-docker
+cargo make build-bundler-audit-master-docker
 ```
 
 The first task will ensure that the Data-forwarder binary is available for the Docker image build to copy it into the image, while the second one will actually build the image.
 
 ## Building the Data-collector docker image
-To build the data-collector Docker image, run `cargo make build-docker-images` from the project root. This target will be kept updated with all of the docker image targets. It also includes linting and unit testing of the code being built. If you want a faster iteration cycle, you can cd into the directory of the component you're working on and run `cargo make musl-build && cargo make build-image`. These commands make use of build caching, so while the first build will be slow as dependencies need to be built for the `musl` target, subsequent builds should be much faster. Running that command will result in a tagged docker image: kiln/data-collector:latest.
+To build the data-collector Docker image, run `cargo make build-docker-images` from the project root. This target will be kept updated with all of the docker image targets. It also includes linting and unit testing of the code being built. If you want a faster iteration cycle, you can cd into the directory of the component you're working on and run `cargo make build-data-collector-master-docker`. These commands make use of build caching, so while the first build will be slow as dependencies need to be built for the `musl` target, subsequent builds should be much faster. Running that command will result in a tagged docker image: kiln/data-collector:master-latest.
 
 ## Generating TLS certificates
 Kiln expects to connect to a Kafka cluster over TLS only, so in order to run a stack locally, we need to setup a basic PKI to ensure certificates can be validated and the connection will be successful. This process has been scripted, but still requires a small amount of user interaction.
@@ -41,7 +41,7 @@ Run `docker exec -it kiln_kafka_1 bash` to get a shell within the running Kafka 
 Then to start the console consumer, run `$KAFKA_HOME/bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic ToolReports --consumer.config /tls/client-ssl.properties --from-beginning`. Now if you send a valid HTTP request to the data-collector, you should see a serialised Avro message printed in this terminal.
 
 ## Running a tool image against a local Kiln stack
-Using the Bundler-audit tool image as an example, this command will start the tool, mounting the current working directory for analysis and report it to a locally running Kiln stack: `docker run -it -v "${PWD}:/code" --net host -e SCAN_ENV="Local" -e APP_NAME="Railsgoat" -e DATA_COLLECTOR_URL="http://localhost:8081" kiln/bundler-audit:0.6.1`
+Using the Bundler-audit tool image as an example, this command will start the tool, mounting the current working directory for analysis and report it to a locally running Kiln stack: `docker run -it -v "${PWD}:/code" --net host -e SCAN_ENV="Local" -e APP_NAME="Railsgoat" -e DATA_COLLECTOR_URL="http://localhost:8081" kiln/bundler-audit:master-latest`
 
 A good codebase to test this particular example on is [OWASP RailsGoat](https://github.com/OWASP/railsgoat).
 


### PR DESCRIPTION
# What does this PR change?
- Updated docker-compose.yml to use new image naming format
- Updated integration testing docs to use new image naming format
- Updated integration testing docs to use valid payload with new fields

# Why is it important?
- Fixes broken integration testing stack script
- Resolves inconsistencies in documentation

# Checklist
- [ ] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
