### PR TITLE
Kiln_lib: Correctly applied cfg feature attribute to failure::err_msg use statement

### DIFF
--- a/kiln_lib/src/tool_report.rs
+++ b/kiln_lib/src/tool_report.rs
@@ -2,6 +2,8 @@
 use crate::avro_schema::TOOL_REPORT_SCHEMA;
 #[cfg(feature = "avro")]
 use avro_rs::schema::Schema;
+#[cfg(feature = "avro")]
+use failure::err_msg;
 
 #[cfg(feature = "json")]
 use serde_json::value::Value;
@@ -11,7 +13,6 @@ use crate::validation::ValidationError;
 use std::convert::TryFrom;
 
 use chrono::{DateTime, Utc};
-use failure::err_msg;
 use regex::Regex;
 use serde::Serialize;
 


### PR DESCRIPTION
# What does this PR change?
- Ensures that the `use failure::err_msg;` statement has the correct cfg feature attribute applied

# Why is it important?
- Fixes the build when building kiln_lib without the avro feature enabled

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
