### PR TITLE
Newtype partial eq impls

### DIFF
--- a/kiln_lib/src/tool_report.rs
+++ b/kiln_lib/src/tool_report.rs
@@ -177,6 +177,12 @@ impl std::fmt::Display for ToolName {
     }
 }
 
+impl PartialEq<str> for ToolName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ToolOutput(String);
 

--- a/kiln_lib/src/tool_report.rs
+++ b/kiln_lib/src/tool_report.rs
@@ -252,6 +252,19 @@ impl TryFrom<String> for OutputFormat {
     }
 }
 
+impl TryFrom<&str> for OutputFormat {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "JSON" => Ok(OutputFormat::JSON),
+            "PlainText" => Ok(OutputFormat::PlainText),
+            "" => Err(ValidationError::tool_output_format_empty()),
+            _ => Err(ValidationError::tool_output_format_invalid()),
+        }
+    }
+}
+
 impl std::fmt::Display for OutputFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {

--- a/kiln_lib/src/tool_report.rs
+++ b/kiln_lib/src/tool_report.rs
@@ -274,6 +274,16 @@ impl std::fmt::Display for OutputFormat {
     }
 }
 
+impl PartialEq<str> for OutputFormat {
+    fn eq(&self, other: &str) -> bool {
+        let parsed_other = OutputFormat::try_from(other);
+        match parsed_other {
+            Ok(parsed_other) => parsed_other == *self,
+            _ => false
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct StartTime(DateTime<Utc>);
 


### PR DESCRIPTION
# What does this PR change?
- Adds PartialEq impls for ToolName and OutputFormat
- Adds a TryFrom<&str> impl for OutputFormat to make comparisons less syntactically noisy

# Why is it important?
- Needed for #61 

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
