### PR TITLE
Kiln_lib: Updated PartialEq<&str> impl for ToolName so it works as expected

### DIFF
--- a/kiln_lib/src/tool_report.rs
+++ b/kiln_lib/src/tool_report.rs
@@ -177,9 +177,9 @@ impl std::fmt::Display for ToolName {
     }
 }
 
-impl PartialEq<str> for ToolName {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other
+impl PartialEq<&str> for ToolName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
     }
 }
 


### PR DESCRIPTION
# What does this PR change?
- Makes the PartialEq impl for ToolName work with &str

# Why is it important?
- Needed for #61 

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
