### PR TITLE
Kiln_lib: Updated PartialEq<&str> impl for OutputFormat so it works as expected

### DIFF
--- a/kiln_lib/src/tool_report.rs
+++ b/kiln_lib/src/tool_report.rs
@@ -274,9 +274,9 @@ impl std::fmt::Display for OutputFormat {
     }
 }
 
-impl PartialEq<str> for OutputFormat {
-    fn eq(&self, other: &str) -> bool {
-        let parsed_other = OutputFormat::try_from(other);
+impl PartialEq<&str> for OutputFormat {
+    fn eq(&self, other: &&str) -> bool {
+        let parsed_other = OutputFormat::try_from(*other);
         match parsed_other {
             Ok(parsed_other) => parsed_other == *self,
             _ => false


### PR DESCRIPTION
# What does this PR change?
- Makes the PartialEq impl for OutputFormat work with &str

# Why is it important?
- Needed for #61 

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
