### PR TITLE
Kiln_lib: Added AsRef<str> impl to ToolOutput

### DIFF
--- a/kiln_lib/src/tool_report.rs
+++ b/kiln_lib/src/tool_report.rs
@@ -204,6 +204,12 @@ impl std::fmt::Display for ToolOutput {
     }
 }
 
+impl AsRef<str> for ToolOutput {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ToolVersion(Option<String>);
 


### PR DESCRIPTION
# What does this PR change?
- Adds an AsRef<str> impl to the ToolOutput newtype to allow the report-parser to immutably borrow the raw tool output for parsing

# Why is it important?
- Needed for #61 

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
