### PR TITLE
Kiln_lib: Added derived Clone impl to KafkaBootstrapTlsConfig

### DIFF
--- a/kiln_lib/src/kafka.rs
+++ b/kiln_lib/src/kafka.rs
@@ -6,7 +6,7 @@ use kafka::producer::Producer;
 use openssl::error::ErrorStack;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode, SslVersion};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KafkaBootstrapTlsConfig(Vec<String>);
 
 pub fn get_bootstrap_config<I>(vars: &mut I) -> Result<KafkaBootstrapTlsConfig, String>


### PR DESCRIPTION
# What does this PR change?
- Makes KafkaBootstrapTlsConfig impl Clone trait

# Why is it important?
- Allows a config to be reused when a caller needs to setup multiple consumers or producers for Kafka

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
