### PR TITLE
Kiln_lib: Added CVSS to DependencyEvent struct

### DIFF
--- a/kiln_lib/src/avro_schema.rs
+++ b/kiln_lib/src/avro_schema.rs
@@ -35,7 +35,13 @@ pub const DEPENDENCY_EVENT_SCHEMA: &str = r#"
             {"name": "installed_version", "type": "string"},
             {"name": "advisory_id", "type": "string"},
             {"name": "advisory_url", "type": "string"},
-            {"name": "advisory_description", "type": "string"}
+            {"name": "advisory_description", "type": "string"},
+            {"name": "cvss", "type": {
+                "name": "Cvss", "type": "record", "fields": [
+                    {"name": "version", "type": {"type": "enum", "name": "CvssVersion", "symbols": ["Unknown", "V2", "V3"]}},
+                    {"name": "score", "type": ["null", "float"]}]
+                }
+            }
         ]
     }
 "#;

--- a/kiln_lib/src/validation.rs
+++ b/kiln_lib/src/validation.rs
@@ -457,6 +457,46 @@ impl ValidationError {
             json_field_name: Some("advisory_description".into()),
         }
     }
+
+    pub fn cvss_version_not_a_string() -> ValidationError {
+        ValidationError {
+            error_code: 152,
+            error_message: "CVSS Version field not parsable as a string".into(),
+            json_field_name: None,
+        }
+    }
+
+    pub fn cvss_score_not_valid() -> ValidationError {
+        ValidationError {
+            error_code: 153,
+            error_message: "CVSS score not valid".into(),
+            json_field_name: None,
+        }
+    }
+
+    pub fn cvss_version_known_without_score() -> ValidationError {
+        ValidationError {
+            error_code: 154,
+            error_message: "CVSS version is known but score not provided".into(),
+            json_field_name: None,
+        }
+    }
+
+    pub fn cvss_version_unknown_with_score() -> ValidationError {
+        ValidationError {
+            error_code: 155,
+            error_message: "CVSS version is unknown but score was provided".into(),
+            json_field_name: None,
+        }
+    }
+
+    pub fn cvss_not_a_record() -> ValidationError {
+        ValidationError {
+            error_code: 156,
+            error_message: "CVSS avro value not a record".into(),
+            json_field_name: None,
+        }
+    }
 }
 
 #[cfg(feature = "web")]


### PR DESCRIPTION
# What does this PR change?
- Adds the CVSS field to DependencyEvent, which covers the version as well as the score (which may be unknown)
- Adds associated Avro parsing logic

# Why is it important?
- Needed for #61 

# Checklist
- [x] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
