### PR TITLE
Kiln_lib: Added Display Impls for Cvss and CvssVersion

### DIFF
--- a/kiln_lib/src/dependency_event.rs
+++ b/kiln_lib/src/dependency_event.rs
@@ -288,7 +288,7 @@ impl TryFrom<avro_rs::types::Value> for AdvisoryId {
     }
 }
 
-impl std::fmt::Display for AdvisoryId{
+impl std::fmt::Display for AdvisoryId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -308,6 +308,12 @@ impl TryFrom<String> for AdvisoryUrl {
         } else {
             Ok(AdvisoryUrl(Url::parse(&value).unwrap()))
         }
+    }
+}
+
+impl std::fmt::Display for AdvisoryUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0.as_str())
     }
 }
 
@@ -359,7 +365,6 @@ impl TryFrom<avro_rs::types::Value> for AdvisoryDescription {
     }
 }
 
-
 impl std::fmt::Display for AdvisoryDescription {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.0)
@@ -373,11 +378,30 @@ pub enum CvssVersion {
     V3
 }
 
+impl std::fmt::Display for CvssVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CvssVersion::Unknown => write!(f, "Unknown"),
+            CvssVersion::V2 => write!(f, "V2"),
+            CvssVersion::V3 => write!(f, "V3"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(default)]
 pub struct Cvss {
     version: CvssVersion,
     score: Option<f32>
+}
+
+impl std::fmt::Display for Cvss {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self.version {
+            CvssVersion::Unknown => write!(f, "Unknown"),
+            _ => write!(f, "{}({})", self.version.to_string(), self.score.unwrap().to_string())
+        }
+    }
 }
 
 #[cfg(feature = "avro")]


### PR DESCRIPTION
# What does this PR change?
- Adds Display Impls to the Cvss Struct and CvssVersion enum

# Why is it important?
- Needed to be able to include severity in slack-connector (#18)

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
