### PR TITLE
Docs: Update project readme to state minimum supported rust version is 1.40

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Kiln Security Scanners are docker containers with security tools baked into the 
 Please note that this project is released with a Contributor Code of Conduct. By participating in this project, you agree to abide by its terms. The Code of Conduct can be found [here](CODE_OF_CONDUCT.md).
 
 To contribute to Kiln, you'll need the following tools installed:
-- Rust (stable channel, assuming 1.37 as minimum)
+- Rust (stable channel, assuming 1.40 as minimum)
 - Clippy (For linting)
 - Cargo Make (For building docker images)
 - Docker


### PR DESCRIPTION
# What does this PR change?
- Updates minimum supported rust version in README

# Why is it important?
One of our dependencies now requires a more recent version of Rust than 1.37, so we have updated this to the current latest stable release

# Checklist
- [ ] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
