### PR TITLE
Meta: Added tech debt issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech_debt.md
+++ b/.github/ISSUE_TEMPLATE/tech_debt.md
@@ -1,0 +1,28 @@
+---
+name: Technical Debt
+about: Issues pertaining to inconsistent design, out of date approaches etc
+title: "[TECH DEBT]"
+labels: tech-debt
+assignees: ''
+
+---
+
+**Describe the issue**
+A clear and concise description of what the issue is.
+
+**What type of technical debt is this?**
+Is this related to code complexity/refactoring? Design that could be improved? Inconsistent design between components?
+
+**Why is this important?**
+Not all technical debt is of equal importance, why should this be fixed?
+
+**What component(s) does this affect?**
+Is this a project wide issue or limited to specific components?
+
+**How should this be addressed?**
+If possible, break the problem down into some self-contained tasks
+
+**How complex do you think this will be to fix? (Use T-shirt sizing [S/M/L/XL] please)**
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
# What does this PR change?
- Adds an issue template to capture tech debt

# Why is it important?
- Allows project maintainers to collect consistent information about technical debt issues

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
