### PR TITLE
Report-parser: Download NIST NVD 2020 date file on startup

### DIFF
--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut last_updated_time = None;
 
     let mut vulns = HashMap::new();
-    for year in 2002..=2019 {
+    for year in 2002..=2020 {
         let parsed_vulns = download_and_parse_vulns(year.to_string(), last_updated_time, &base_url);
         if let Err(err) = parsed_vulns {
             error!("{}", err);


### PR DESCRIPTION
# What does this PR change?
- Downloads the NIST NVD 2020 date file on startup

# Why is it important?
- Ensures report-parser component has an up-to-date collection of vulnerability information

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
