### PR TITLE
Release Automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install fpm
         run: gem install --no-document fpm
       - name: Build CLI app
-        run: cargo build --release && mkdir ../bin && cp target/release/kiln-cli ../bin/kiln
+        run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli
       - name: Build .deb package
         run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install fpm
         run: gem install --no-document fpm
       - name: Install packaging tools
-        run: sudo apt install -yq dpkg-sig rpmsign rpm
+        run: sudo apt install -yq dpkg-sig rpm
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Setup RPM macros

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,39 @@
 name: Build release artifacts
 on:
-    push:
-        branches:
-            - release_automation
+  push:
+    branches:
+      - release_automation
 
 jobs:
-    source-tarball:
-        name: Archive source
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-              with:
-                path: 'src'
-            - name: Import CI signing key
-              run: echo -e "${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }}" | gpg --import
-            - name: Archive source
-              run: tar -cJf kiln-source.tar.xz src/
-            - name: Hash source archive
-              run: sha256sum kiln-source.tar.xz > kiln-source.tar.xz.sha256
-            - name: Sign hash file
-              run: gpg --output kiln-source.tar.xz.sha256.sig --detach-sig kiln-source.tar.xz.sha256
-            - name: Upload tarball
-              uses: actions/upload-artifact@v1
-              with:
-                name: kiln-source.tar.xz
-                path: kiln-source.tar.xz
-            - name: Upload hash file
-              uses: actions/upload-artifact@v1
-              with:
-                name: kiln-source.tar.xz.sha256
-                path: kiln-source.tar.xz.sha256
-            - name: Upload hash file signature
-              uses: actions/upload-artifact@v1
-              with:
-                name: kiln-source.tar.xz.sha256.sig
-                path: kiln-source.tar.xz.sha256.sig
+  source-tarball:
+    name: Archive source
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: 'src'
+      - name: Import CI signing key
+        run: echo -e "${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }}" | gpg --import
+      - name: Archive source
+        run: tar -cJf kiln-source.tar.xz src/
+      - name: Hash source archive
+        run: sha256sum kiln-source.tar.xz > kiln-source.tar.xz.sha256
+      - name: Sign hash file
+        run: gpg --output kiln-source.tar.xz.sha256.sig --detach-sig kiln-source.tar.xz.sha256
+      - name: Upload tarball
+        uses: actions/upload-artifact@v1
+        with:
+          name: kiln-source.tar.xz
+          path: kiln-source.tar.xz
+      - name: Upload hash file
+        uses: actions/upload-artifact@v1
+        with:
+          name: kiln-source.tar.xz.sha256
+          path: kiln-source.tar.xz.sha256
+      - name: Upload hash file signature
+        uses: actions/upload-artifact@v1
+        with:
+          name: kiln-source.tar.xz.sha256.sig
+          path: kiln-source.tar.xz.sha256.sig
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,6 @@ jobs:
         run: sudo apt install -yq dpkg-sig
         env:
           DEBIAN_FRONTEND: noninteractive
-      - name: Setup RPM macros
-        run: cp .rpmmacros ~/.rpmmacros
       - name: Build CLI app
         run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,4 +55,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: deb-package
-          path: *.deb
+          path: "*.deb"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ jobs:
                 path: 'src'
             - name: Install GPG
               run: apt update && apt install -yq gnupg
-              env: DEBIAN_FRONTEND=noninteractive
+              env:
+                DEBIAN_FRONTEND: noninteractive
             - name: Import CI signing key
               run: echo ${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }} | gpg --import
             - name: Archive source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Install fpm
         run: gem install --no-document fpm
       - name: Build CLI app
-        run: cargo build --release && mkdir bin && cp target/release/kiln-cli ./bin/kiln
+        run: cargo build --release && mkdir ../bin && cp target/release/kiln-cli ../bin/kiln
+        working_directory: cli
       - name: Build .deb package
         run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "xz" --deb-dist-tag "buster"
       - name: Upload .deb package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: gem install --no-document fpm
       - name: Build CLI app
         run: cargo build --release && mkdir ../bin && cp target/release/kiln-cli ../bin/kiln
-        working_directory: cli
+        working-directory: cli
       - name: Build .deb package
         run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "xz" --deb-dist-tag "buster"
       - name: Upload .deb package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,9 @@ jobs:
         run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli
       - name: Build .deb package
-        run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
+        run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" -d "openssl > 1.1" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
       - name: Build .rpm package
-        run: fpm -s dir -t rpm -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker-ce > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --rpm-digest "sha256" --rpm-os "linux" 
+        run: fpm -s dir -t rpm -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker-ce > 18.09" -d "openssl > 1.1" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --rpm-digest "sha256" --rpm-os "linux" 
       - name: Upload .deb package
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build .deb package
         run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
       - name: Build .rpm package
-        run: fpm -s dir -t rpm -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker-ce > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
+        run: fpm -s dir -t rpm -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker-ce > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --rpm-digest "sha256" --rpm-os "linux" 
       - name: Upload .deb package
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,8 @@ jobs:
         %_gpg_path /root/.gnupg
         %_gpg_name Kiln Automated Builder
         %_gpgbin /usr/bin/gpg2
-        %__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'
+        %__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}
+        EOF
       - name: Build CLI app
         run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
               with:
                 path: 'src'
             - name: Install GPG
-              run: apt update && apt install -yq gnupg
+              run: sudo apt update && sudo apt install -yq gnupg
               env:
                 DEBIAN_FRONTEND: noninteractive
             - name: Import CI signing key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,4 +39,4 @@ jobs:
               uses: actions/upload-artifact@v1
               with:
                 name: kiln-source.tar.xz.sha256.sig
-                path: kiln-source.tar.xz.sha256.si6
+                path: kiln-source.tar.xz.sha256.sig

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         run: cargo build --release && mkdir ../bin && cp target/release/kiln-cli ../bin/kiln
         working-directory: cli
       - name: Build .deb package
-        run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "xz" --deb-dist-tag "buster"
+        run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "xz" --deb-dist "buster"
       - name: Upload .deb package
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
               env:
                 DEBIAN_FRONTEND: noninteractive
             - name: Import CI signing key
-              run: echo ${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }} | gpg --import
+              run: gpg --import < $(echo ${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }})
             - name: Archive source
               run: tar -cJf kiln-source.tar.xz src/
             - name: Hash source archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,28 @@ jobs:
           ruby-version: 2.6.x
       - name: Install fpm
         run: gem install --no-document fpm
+      - name: Install packaging tools
+        run: sudo apt install -yq dpkg-sig rpm
+        env:
+          DEBIAN_FRONTEND: noninteractive
+      - name: Setup RPM macros
+        run: cat > .rpmmacros <<'EOF'
+        %_signature gpg
+        %_gpg_path /root/.gnupg
+        %_gpg_name Kiln Automated Builder
+        %_gpgbin /usr/bin/gpg2
+        %__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'
       - name: Build CLI app
         run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli
       - name: Build .deb package
         run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" -d "openssl > 1.1" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
+      - name: Sign .deb package
+        run: dpkg-sig --sign builder kiln-cli_0.2.0_amd64.deb
       - name: Build .rpm package
         run: fpm -s dir -t rpm -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker-ce > 18.09" -d "openssl > 1.1" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --rpm-digest "sha256" --rpm-os "linux" 
+      - name: Sign .rpm package
+        run: rpm --addsign kiln-cli-0.2.0-1.x86_64.rpm
       - name: Upload .deb package
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,14 +56,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Setup RPM macros
-        run: |
-        cat > .rpmmacros <<'EOF'
-        %_signature gpg
-        %_gpg_path /root/.gnupg
-        %_gpg_name Kiln Automated Builder
-        %_gpgbin /usr/bin/gpg2
-        %__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}
-        EOF
+        run: cp .rpmmacros ~/.rpmmacros
       - name: Build CLI app
         run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,11 @@ jobs:
       - name: Install fpm
         run: gem install --no-document fpm
       - name: Install packaging tools
-        run: sudo apt install -yq dpkg-sig
+        run: sudo apt install -yq dpkg-sig rpmsign rpm
         env:
           DEBIAN_FRONTEND: noninteractive
+      - name: Setup RPM macros
+        run: cp .rpmmacros ~/.rpmmacros
       - name: Build CLI app
         run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli
       - name: Build .deb package
-        run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" -d "openssl > 1.1" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
+        run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker-ce" -d "openssl > 1.1" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
       - name: Sign .deb package
         run: dpkg-sig --sign builder kiln-cli_0.2.0_amd64.deb
       - name: Upload .deb package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Build release artifacts
+on:
+    push:
+        branches:
+            - release_automation
+
+jobs:
+    source-tarball:
+        name: Data-collector build
+        runs-on: ubuntu-18.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                path: 'src'
+            - name: Install GPG
+              run: apt update && apt install -yq gnupg
+              env: DEBIAN_FRONTEND=noninteractive
+            - name: Import CI signing key
+              run: echo ${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }} | gpg --import
+            - name: Archive source
+              run: tar -cJf kiln-source.tar.xz src/
+            - name: Hash source archive
+              run: sha256sum kiln-source.tar.xz > kiln-source.tar.xz.sha256
+            - name: Sign hash file
+              run: gpg --output kiln-source.tar.xz.sha256.sig --detach-sig kiln-source.tar.xz.sha256
+            - name: Upload tarball
+              uses: actions/upload-artifact@v1
+              with:
+                name: kiln-source.tar.xz
+                path: kiln-source.tar.xz
+            - name: Upload hash file
+              uses: actions/upload-artifact@v1
+              with:
+                name: kiln-source.tar.xz.sha256
+                path: kiln-source.tar.xz.sha256
+            - name: Upload hash file signature
+              uses: actions/upload-artifact@v1
+              with:
+                name: kiln-source.tar.xz.sha256.sig
+                path: kiln-source.tar.xz.sha256.si6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,4 +60,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: deb-package
-          path: "*.deb"
+          path: "kiln-cli_0.2.0_amd64.deb"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Ruby 2.6
         uses: actions/setup-ruby@v1
         with:
-          version: 2.6.x
+          ruby-version: 2.6.x
       - name: Install fpm
         run: gem install --no-document fpm
       - name: Build CLI app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,4 +67,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: rpm-package
-          path: "kiln-cli_0.2.0_amd64.rpm"
+          path: "kiln-cli-0.2.0-1.x86_64.rpm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     source-tarball:
-        name: Data-collector build
+        name: Archive source
         runs-on: ubuntu-18.04
         steps:
             - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,22 @@ jobs:
           name: kiln-source.tar.xz.sha256.sig
           path: kiln-source.tar.xz.sha256.sig
 
+  build-linux-packages:
+    name: Build linux packages
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Import CI signing key
+        run: echo -e "${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }}" | gpg --import
+      - name: Install fpm
+        run: gem install --no-document fpm
+      - name: Build CLI app
+        run: cargo build --release && mkdir bin && cp target/release/kiln-cli ./bin/kiln
+      - name: Build .deb package
+        run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "xz" --deb-dist-tag "buster"
+      - name: Upload .deb package
+        uses: actions/upload-artifact@v1
+        with:
+          name: deb-package
+          path: *.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Import CI signing key
         run: echo -e "${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }}" | gpg --import
+      - name: Set up Ruby 2.6
+        uses: actions/setup-ruby@v1
+        with:
+          version: 2.6.x
       - name: Install fpm
         run: gem install --no-document fpm
       - name: Build CLI app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,9 @@ jobs:
       - name: Install fpm
         run: gem install --no-document fpm
       - name: Install packaging tools
-        run: sudo apt install -yq dpkg-sig rpm
+        run: sudo apt install -yq dpkg-sig
         env:
           DEBIAN_FRONTEND: noninteractive
-      - name: Setup RPM macros
-        run: cp .rpmmacros ~/.rpmmacros
       - name: Build CLI app
         run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli
@@ -64,15 +62,8 @@ jobs:
         run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" -d "openssl > 1.1" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
       - name: Sign .deb package
         run: dpkg-sig --sign builder kiln-cli_0.2.0_amd64.deb
-      - name: Build .rpm package
-        run: fpm -s dir -t rpm -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker-ce > 18.09" -d "openssl > 1.1" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --rpm-digest "sha256" --rpm-os "linux" --rpm-sign
       - name: Upload .deb package
         uses: actions/upload-artifact@v1
         with:
           name: deb-package
           path: "kiln-cli_0.2.0_amd64.deb"
-      - name: Upload .rpm package
-        uses: actions/upload-artifact@v1
-        with:
-          name: rpm-package
-          path: "kiln-cli-0.2.0-1.x86_64.rpm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,14 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Setup RPM macros
-        run: 'cat > .rpmmacros <<\'EOF\'
+        run: |
+        cat > .rpmmacros <<'EOF'
         %_signature gpg
         %_gpg_path /root/.gnupg
         %_gpg_name Kiln Automated Builder
         %_gpgbin /usr/bin/gpg2
         %__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}
-        EOF'
+        EOF
       - name: Build CLI app
         run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,13 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Setup RPM macros
-        run: cat > .rpmmacros <<'EOF'
+        run: 'cat > .rpmmacros <<\'EOF\'
         %_signature gpg
         %_gpg_path /root/.gnupg
         %_gpg_name Kiln Automated Builder
         %_gpgbin /usr/bin/gpg2
         %__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}
-        EOF
+        EOF'
       - name: Build CLI app
         run: cargo build --release && mkdir -p ../bin/usr/bin && cp target/release/kiln-cli ../bin/usr/bin/kiln
         working-directory: cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         run: cargo build --release && mkdir ../bin && cp target/release/kiln-cli ../bin/kiln
         working-directory: cli
       - name: Build .deb package
-        run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "xz" --deb-dist "buster"
+        run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
       - name: Upload .deb package
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,15 @@ jobs:
         working-directory: cli
       - name: Build .deb package
         run: fpm -s dir -t deb -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker.io > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
+      - name: Build .rpm package
+        run: fpm -s dir -t rpm -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker-ce > 18.09" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --deb-compression "gz" --deb-dist "buster"
       - name: Upload .deb package
         uses: actions/upload-artifact@v1
         with:
           name: deb-package
           path: "kiln-cli_0.2.0_amd64.deb"
+      - name: Upload .rpm package
+        uses: actions/upload-artifact@v1
+        with:
+          name: rpm-package
+          path: "kiln-cli_0.2.0_amd64.rpm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,6 @@ jobs:
               uses: actions/checkout@v2
               with:
                 path: 'src'
-            - name: Install GPG
-              run: sudo apt update && sudo apt install -yq gnupg
-              env:
-                DEBIAN_FRONTEND: noninteractive
             - name: Import CI signing key
               run: echo -e "${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }}" | gpg --import
             - name: Archive source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install fpm
         run: gem install --no-document fpm
       - name: Install packaging tools
-        run: sudo apt install -yq dpkg-sig rpm
+        run: sudo apt install -yq dpkg-sig
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Setup RPM macros
@@ -65,9 +65,7 @@ jobs:
       - name: Sign .deb package
         run: dpkg-sig --sign builder kiln-cli_0.2.0_amd64.deb
       - name: Build .rpm package
-        run: fpm -s dir -t rpm -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker-ce > 18.09" -d "openssl > 1.1" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --rpm-digest "sha256" --rpm-os "linux" 
-      - name: Sign .rpm package
-        run: rpm --addsign kiln-cli-0.2.0-1.x86_64.rpm
+        run: fpm -s dir -t rpm -C bin --name "kiln-cli" -v 0.2.0 --license MIT --vendor "Simply Business" -d "docker-ce > 18.09" -d "openssl > 1.1" --provides "kiln" -m "kiln@simplybusiness.co.uk" --url "https://github.com/simplybusiness/Kiln" --rpm-digest "sha256" --rpm-os "linux" --rpm-sign
       - name: Upload .deb package
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
               env:
                 DEBIAN_FRONTEND: noninteractive
             - name: Import CI signing key
-              run: gpg --import < $(echo ${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }})
+              run: echo -e "${{ secrets.AUTOMATED_SIGNING_PRIVATE_KEY }}" | gpg --import
             - name: Archive source
               run: tar -cJf kiln-source.tar.xz src/
             - name: Hash source archive

--- a/.rpmmacros
+++ b/.rpmmacros
@@ -1,0 +1,5 @@
+%_signature gpg
+%_gpg_path /root/.gnupg
+%_gpg_name Package Manager
+%_gpgbin /usr/bin/gpg2
+%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'

--- a/.rpmmacros
+++ b/.rpmmacros
@@ -2,4 +2,4 @@
 %_gpg_path ~/.gnupg
 %_gpg_name Package Manager
 %_gpgbin /usr/bin/gpg2
-%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'
+%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'

--- a/.rpmmacros
+++ b/.rpmmacros
@@ -1,5 +1,0 @@
-%_signature gpg
-%_gpg_path ~/.gnupg
-%_gpg_name Package Manager
-%_gpgbin /usr/bin/gpg2
-%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --no-tty --yes --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'

--- a/.rpmmacros
+++ b/.rpmmacros
@@ -1,5 +1,5 @@
 %_signature gpg
-%_gpg_path /root/.gnupg
+%_gpg_path ~/.gnupg
 %_gpg_name Package Manager
 %_gpgbin /usr/bin/gpg2
 %__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'

--- a/.rpmmacros
+++ b/.rpmmacros
@@ -2,4 +2,4 @@
 %_gpg_path ~/.gnupg
 %_gpg_name Package Manager
 %_gpgbin /usr/bin/gpg2
-%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'
+%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --no-tty --yes --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'

--- a/.rpmmacros
+++ b/.rpmmacros
@@ -1,4 +1,0 @@
-%_signature gpg
-%_gpg_path ~/.gnupg
-%_gpg_name "Kiln Automated Builder"
-%_gpgbin /usr/bin/gpg

--- a/.rpmmacros
+++ b/.rpmmacros
@@ -1,0 +1,4 @@
+%_signature gpg
+%_gpg_path ~/.gnupg
+%_gpg_name "Kiln Automated Builder"
+%_gpgbin /usr/bin/gpg


### PR DESCRIPTION
# What does this PR change?
- Adds a CI release workflow that is triggered on tag pushes with release tag pattern
- Validates tag signature
- Creates a draft GitHub release
- Archives source, hashes and signs archive and uploads all to release
- Builds .deb package and uploads to release
- Builds and tags docker images

# Notable omissions
- Does not build RPMs
- Does not push tagged docker images (Includes commented out steps, will be enabled in later PR after testing)
- Does not build for MacOS
- Correct handling of SemVer pre-releases (Not publishing the latest stable tag for docker images, marking GitHub release as a pre-release etc)

# Why is it important?
- Fulfils some of #44 

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
