### PR TITLE
Add TLS support to Bundler-audit tool image

### DIFF
--- a/data-forwarder/Cargo.lock
+++ b/data-forwarder/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kiln_lib 0.1.0 (git+https://github.com/simplybusiness/Kiln)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/data-forwarder/Cargo.toml
+++ b/data-forwarder/Cargo.toml
@@ -10,3 +10,4 @@ chrono = "0.4"
 reqwest = "0.9" 
 git2 = "0.10"
 uuid = { version = "0.8", features = ["v4"] }
+openssl-probe = "0.1.2"

--- a/data-forwarder/src/main.rs
+++ b/data-forwarder/src/main.rs
@@ -13,6 +13,8 @@ use git2::Repository;
 use uuid::Uuid;
 
 fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
+    openssl_probe::init_ssl_cert_env_vars();
+
     let matches = App::new("Kiln data forwarder")
 			.arg(Arg::with_name("tool_name")
 				.help("Name of the security tool run")

--- a/tool-images/ruby/bundler-audit/Dockerfile
+++ b/tool-images/ruby/bundler-audit/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:2-alpine
+RUN apk --no-cache add ca-certificates
 RUN apk --no-cache add git
 RUN gem install bundler -v "~>1.0" && \
     gem install bundler -v "~>2.0"


### PR DESCRIPTION
# What does this PR change?
- Updated data-forwarder to use openssl-probe to find system CA certificate bundle
- Installs the ca-certificates Alpine package in Docker image for bundler-audit

# Why is it important?
- Allows sensitive information about project security issues to be sent over TLS

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
