### PR TITLE
Fork of Dan's changes and Rich's updated gen_cert.sh

### DIFF
--- a/gen_certs.sh
+++ b/gen_certs.sh
@@ -8,16 +8,16 @@ cp client-ssl.properties tls/
 pushd tls
 #Step 1
 #Generate server keystore
-keytool -keystore kafka.server.keystore.jks -alias localhost -validity 365 -genkey -keyalg rsa -storepass password -keypass password -dname "C=GB, ST=London, O=Kiln, OU=Integration Testing, CN=Kafka"
+keytool -keystore kafka.keystore.jks -alias localhost -validity 365 -genkey -keyalg rsa -storepass password -keypass password -dname "C=GB, ST=London, O=Kiln, OU=Integration Testing, CN=Kafka"
 #Step 2
 #Create CA
 openssl req -new -x509 -keyout ca-key -out ca-cert -days 365 -nodes -subj "/C=GB/ST=London/O=Kiln/OU=Integration Test/CN=Kafka CA"
 #Add generated CA to the trust store
-keytool -keystore kafka.server.truststore.jks -alias CARoot -import -file ca-cert -storepass password
+keytool -keystore kafka.truststore.jks -alias CARoot -import -file ca-cert -storepass password
 #Step 3
 #Sign the key store
-keytool -keystore kafka.server.keystore.jks -alias localhost -certreq -file cert-file -storepass password -sigalg SHA256withRSA
+keytool -keystore kafka.keystore.jks -alias localhost -certreq -file cert-file -storepass password -sigalg SHA256withRSA
 openssl x509 -req -CA ca-cert -CAkey ca-key -in cert-file -out cert-signed -days 365 -CAcreateserial -passin pass:password -extfile ssl.cnf -extensions req_ext -sha256
-keytool -keystore kafka.server.keystore.jks -alias CARoot -import -file ca-cert -storepass password
-keytool -keystore kafka.server.keystore.jks -alias localhost -import -file cert-signed -storepass password 
+keytool -keystore kafka.keystore.jks -alias CARoot -import -file ca-cert -storepass password
+keytool -keystore kafka.keystore.jks -alias localhost -import -file cert-signed -storepass password 
 popd


### PR DESCRIPTION
# What does this PR change?
updates gen_cert.sh so the keystore location is correct. Previously the path included 'server'.
i.e. kafka.server.keystore.jks and kafka.server.truststore.jks

This PR is a fork of https://github.com/simplybusiness/kiln master repo - it includes the changes made my Dan on 24th April 2020

# Why is it important?
Incorrect keystore location creates fatal error e.g. 
org.apache.kafka.common.KafkaException: Failed to load SSL keystore /opt/bitnami/kafka/conf/certs/kafka.keystore.jks of type JKS


# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
