### PR TITLE
Data-collector: Update documentation for providing TLS certificates to container

### DIFF
--- a/data-collector/README.md
+++ b/data-collector/README.md
@@ -15,7 +15,7 @@ This component is configured using environment variables. Ensure that the enviro
 
 By default, this component will validate that hosts in the `KAFKA_BOOTSTRAP_TLS` environment variable are valid domain names. If you need to connect to a cluster using bare hostnames, you can disable this validation by setting: `DISABLE_KAFKA_DOMAIN_VALIDATION=true`.
 
-If your Kafka cluster uses TLS certificates issued by a private Certificate Authority, you will need to provide the CA Certificate in PEM format so that certificate validation can be performed when connecting to the Kafka cluster. The easiest way to achieve this is to add an additional volume when starting the data-collector Docker container containing the CA Certificate and set the `SSL_CERT_FILE` environment variable with the path to the CA Certificate inside the docker container.
+If your Kafka cluster uses TLS certificates issued by a private Certificate Authority, you will need to provide the CA Certificate in PEM format so that certificate validation can be performed when connecting to the Kafka cluster. You should do this by including the CA certificate in PEM format in the `/tls` directory of the container, probably through a volume mount. 
 
 ## Request & Response Documentation
 


### PR DESCRIPTION
# What does this PR change?
- Updates documentation to reflect changes to how CA certs are provided to data-collector container, which closes #130 

# Why is it important?
- Documentation accuracy

# Checklist
- [ ] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
