### PR TITLE
Respect slack api limits

### DIFF
--- a/slack-connector/Cargo.lock
+++ b/slack-connector/Cargo.lock
@@ -1235,8 +1235,10 @@ name = "slack-connector"
 version = "0.1.0"
 dependencies = [
  "avro-rs 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kiln_lib 0.1.0 (git+https://github.com/simplybusiness/Kiln)",

--- a/slack-connector/Cargo.lock
+++ b/slack-connector/Cargo.lock
@@ -324,6 +324,11 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-util"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1244,7 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kiln_lib 0.1.0 (git+https://github.com/simplybusiness/Kiln)",
@@ -1689,6 +1695,7 @@ dependencies = [
 "checksum futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 "checksum futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
 "checksum futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+"checksum futures-timer 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 "checksum futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"

--- a/slack-connector/Cargo.toml
+++ b/slack-connector/Cargo.toml
@@ -19,3 +19,4 @@ rdkafka = { version = "0.23", features = ["cmake-build", "ssl-vendored"] }
 futures = "0.3"
 futures-util = "0.3"
 hex = { version = "0.4", features = ["serde"] }
+futures-timer = "3"

--- a/slack-connector/Cargo.toml
+++ b/slack-connector/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 avro-rs = "0.6"
+bytes = "0.5"
 failure = "0.1"
 kiln_lib = { git = "https://github.com/simplybusiness/Kiln", branch = "master", features = ["avro", "streaming"] }
 serde = "1"
@@ -15,5 +16,6 @@ log = "0.4"
 env_logger = "0.7"
 tokio = { version = "0.2", features = ["full"] }
 rdkafka = { version = "0.23", features = ["cmake-build", "ssl-vendored"] }
+futures = "0.3"
 futures-util = "0.3"
 hex = { version = "0.4", features = ["serde"] }

--- a/slack-connector/src/main.rs
+++ b/slack-connector/src/main.rs
@@ -11,8 +11,6 @@ use rdkafka::consumer::Consumer;
 use rdkafka::message::Message;
 use rdkafka::Offset;
 use reqwest::Client;
-use reqwest::Method;
-use serde_json::{json, Value};
 use std::boxed::Box;
 use std::convert::TryFrom;
 use std::env;
@@ -20,6 +18,9 @@ use std::error::Error;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
+use reqwest::Method;
+use serde_json::{json, Value};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -34,17 +35,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let tls_cert_path = PathBuf::from_str("/etc/ssl/certs/ca-certificates.crt").unwrap();
 
-    let consumer = Arc::new(
-        build_kafka_consumer(config, "slack-connector".to_string(), &tls_cert_path)
-            .map_err(|err| err_msg(format!("Kafka Consumer Error: {}", err.to_string())))?,
-    );
+    let consumer = Arc::new(build_kafka_consumer(
+        config,
+        "slack-connector".to_string(),
+        &tls_cert_path,
+    )
+    .map_err(|err| err_msg(format!("Kafka Consumer Error: {}", err.to_string())))?);
 
     let client = Client::new();
-    let (queue_tx, queue_rx) =
-        futures::channel::mpsc::channel::<(i64, Vec<Result<DependencyEvent, _>>)>(10);
+    let (queue_tx, queue_rx) = futures::channel::mpsc::channel::<(i64, Vec<Result<DependencyEvent, _>>)>(10);
 
     consumer.subscribe(&["DependencyEvents"])?;
-    let avro_bytes = consumer.start_with(std::time::Duration::from_secs(1), false);
+    let avro_bytes = consumer.start_with(Duration::from_secs(1), false);
     let mut events = avro_bytes
         .map_ok(|message| message.detach())
         .map_err(|err| failure::Error::from_boxed_compat(Box::new(err)))
@@ -58,16 +60,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let reader_result = Reader::new(body_bytes.reader());
             match reader_result {
                 Ok(reader) => Ok((offset, reader)),
-                Err(_) => Err(err_msg("Could not parse avro value from bytes")),
+                Err(_) => Err(err_msg("Could not parse avro value from bytes"))
             }
         })
         .map_ok(|(offset, reader)| {
-            (
-                offset,
-                reader
-                    .map(|event| DependencyEvent::try_from(event?))
-                    .collect(),
-            )
+            (offset, reader.map(|event| DependencyEvent::try_from(event?)).collect())
         })
         .boxed();
 
@@ -84,41 +81,32 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 }
                 if let Ok(event) = event {
                     if !event.suppressed {
-                        let payload = json!({
-                            "channel": dispatch_channel_id,
-                            "text": event.to_slack_message()
-                        });
-                        let req = dispatch_client
-                            .request(Method::POST, "https://slack.com/api/chat.postMessage")
-                            .bearer_auth(&dispatch_oauth_token)
-                            .json(&payload)
-                            .build()?;
-                        let resp = dispatch_client.execute(req).await?;
-                        let resp_body: Value = resp.json().await?;
-                        if !resp_body.get("ok").unwrap().as_bool().unwrap() {
-                            let cause = resp_body.get("error").unwrap().as_str().unwrap();
-                            eprintln!(
-                                "Error sending message for event {}, parent {}, {}",
-                                event.event_id.to_string(),
-                                event.parent_event_id.to_string(),
-                                cause
-                            );
-                            //HANDLE RETRY HERE
+                        while let Err(err) = try_send_slack_message(dispatch_channel_id, event, dispatch_client, dispatch_oauth_token).await {
+                            match err {
+                                SlackSendError::RateLimited(delay) => {
+                                    eprintln!("Error sending slack message for EventID {}, Parent Event ID {}: Encountered rate limit, waiting {} seconds before trying again", event.event_id, event.parent_event_id, delay.as_secs());
+                                    futures_timer::Delay::new(delay).await;
+                                },
+                                SlackSendError::Unknown(err) => {
+                                    eprintln!("Error sending slack message for EventID {}, Parent Event ID {}: {}", event.event_id, event.parent_event_id, err);
+                                    futures_timer::Delay::new(Duration::from_secs(1)).await;
+                                }
+                            }
                         }
+                        futures_timer::Delay::new(Duration::from_secs(1)).await;
                     }
                 }
             }
-            dispatch_consumer
-                .assignment()
-                .unwrap()
-                .set_all_offsets(Offset::from_raw(offset));
+            dispatch_consumer.assignment().unwrap().set_all_offsets(Offset::from_raw(offset));
             Ok::<(), failure::Error>(())
         })
         .collect::<Vec<_>>();
 
-    let mut queue_tx_mapped = queue_tx.sink_err_into();
+    let mut queue_tx_mapped = queue_tx
+        .sink_err_into();
 
-    let queue_all = queue_tx_mapped.send_all(&mut events);
+    let queue_all = queue_tx_mapped
+        .send_all(&mut events);
 
     let results = futures::join!(queue_all, slack_dispatch);
     results.0?;
@@ -146,4 +134,49 @@ impl ToSlackMessage for DependencyEvent {
             hex::encode(self.hash()),
         )
     }
+}
+
+enum SlackSendError {
+    RateLimited(std::time::Duration),
+    Unknown(failure::Error)
+}
+
+impl From<reqwest::Error> for SlackSendError {
+    fn from(val: reqwest::Error) -> Self {
+        SlackSendError::Unknown(val.into())
+    }
+}
+
+async fn try_send_slack_message<T : AsRef<str> + serde::ser::Serialize + std::fmt::Display>(channel_id: T, event: &DependencyEvent, client: &reqwest::Client, oauth_token: T) -> Result<(), SlackSendError> {
+    let payload = json!({
+        "channel": channel_id,
+        "text": event.to_slack_message()
+    });
+    let req = client
+        .request(Method::POST, "https://slack.com/api/chat.postMessage")
+        .bearer_auth(&oauth_token)
+        .json(&payload)
+        .build()
+        .map_err(|err| SlackSendError::from(err))?;
+    let resp = client.execute(req).await?;
+    let retry_delay: Option<std::time::Duration> = resp.headers()
+        .get("Retry-After")
+        .map(|val| Duration::from_secs(val.to_str().unwrap().parse().unwrap()));
+
+    let resp_body: Value = resp.json().await?;
+    if !resp_body.get("ok").unwrap().as_bool().unwrap() {
+        let cause = resp_body.get("error").unwrap().as_str().unwrap();
+        eprintln!(
+            "Error sending message for event {}, parent {}, {}",
+            event.event_id.to_string(),
+            event.parent_event_id.to_string(),
+            cause
+        );
+        return if cause == "rate_limited" {
+            Err(SlackSendError::RateLimited(retry_delay.unwrap_or(Duration::from_secs(30))))
+        } else {
+            Err(SlackSendError::Unknown(err_msg(cause.to_owned())))
+        }
+    }
+    Ok(())
 }

--- a/slack-connector/src/main.rs
+++ b/slack-connector/src/main.rs
@@ -65,10 +65,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         })
         .boxed();
 
-    queue_tx
-        .sink_map_err(|_| err_msg("Could not send event to stream"))
+    let mut queue_tx_mapped = queue_tx
+        .sink_err_into();
+
+    let queue_all = queue_tx_mapped
         .send_all(&mut events);
 
+    futures::try_join!(queue_all);
     Ok(())
 }
 


### PR DESCRIPTION
# What does this PR change?

* Ensures that slack messages are not sent more often than 1 per second for each replica of the Slack Connector
* Switches to a stream pipeline approach to consuming and dispatching events, to decouple these processes
* Adds retry logic for Slack messages that couldn't be sent
* Adds a backoff timer for Slack API requests that return a rate limited response, respecting the Retry-After header value, defaulting to 30 seconds if one isn't provided

# Why is it important?

* To be good citizens and respectful of Slack's documented API rate limits (and to avoid having the Slack Connector banned by Slack!)
* Closes #143 

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
