### PR TITLE
RPM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "utils/rpm-builder"]
+	path = utils/rpm-builder
+	url = https://github.com/Richterrettich/rpm-builder.git

--- a/cli/Makefile.toml
+++ b/cli/Makefile.toml
@@ -9,6 +9,31 @@ script = [
 	"cargo build --release"
 ] 
 
+[tasks.rpm]
+dependencies = [
+	"build-rpm-builder",
+	"musl-build",
+	"build-rpm",
+	"move-rpm"
+]
+
+[tasks.build-rpm]
+script = [
+"../utils/rpm-builder/target/release/rpm-builder --exec-file target/x86_64-unknown-linux-musl/release/kiln-cli:/usr/bin/kiln-cli --compression gzip --arch x86_64 --desc 'CLI Tool for running security tools to send data to a Kiln stack' --license MIT --version $CARGO_MAKE_CRATE_VERSION kiln-cli-$CARGO_MAKE_CRATE_VERSION",
+]
+
+[tasks.move-rpm]
+script  = [
+	"mkdir -p target/rpm",
+	"mv *.rpm target/rpm/"
+]
+
+[tasks.build-rpm-builder]
+script = [
+	"cd ../utils/rpm-builder/",
+	"cargo build --release"
+]
+
 [tasks.musl-build]
 script = [
 	"mkdir target &> /dev/null || true",

--- a/cli/Makefile.toml
+++ b/cli/Makefile.toml
@@ -9,6 +9,13 @@ script = [
 	"cargo build --release"
 ] 
 
+[tasks.musl-build]
+script = [
+	"mkdir target &> /dev/null || true",
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 cargo build --release"
+]
+
 [tasks.copy-binary-to-root-dir]
 script = [
 	"mkdir -p ../bin && cp ./target/release/kiln-cli ../bin"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -100,6 +100,7 @@ impl ConfigFileError {
 async fn main() -> Result<(), Box<dyn Error>> {
     let matches = App::new("Kiln CLI")
         .setting(AppSettings::SubcommandRequired)
+        .version(clap::crate_version!())
         .arg(Arg::with_name("use-local-image")
             .long("use-local-image")
             .help("Do not try and pull the latest version of a tool image. Useful for development and scanning without network access"))


### PR DESCRIPTION
# What does this PR change?
- Adds dependency on [rpm-builder](https://github.com/Richterrettich/rpm-builder) project as a git submodule
- Adds `rpm` target to CLI Makefile
- Fixes --version switch so that packaged CLI binary will show the correct version

Note: The Makefile.toml script does not produce a signed RPM. This is because the key needs to be decrypted with a password to enable the signing, but the pin entry dialog is not shown by cargo-make, which leads to a timeout error. This needs to be performed manually by running the following command:

`rpmsign --addsign --key-id=KEYID --digest-algo=sha512 PATH-TO-RPM-FILE`

# Why is it important?
- Contributes to #165 

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
