### PR TITLE
CLI: Fix RPM file naming by appending arch to name

### DIFF
--- a/cli/Makefile.toml
+++ b/cli/Makefile.toml
@@ -19,7 +19,7 @@ dependencies = [
 
 [tasks.build-rpm]
 script = [
-"../utils/rpm-builder/target/release/rpm-builder --exec-file target/x86_64-unknown-linux-musl/release/kiln-cli:/usr/bin/kiln-cli --compression gzip --arch x86_64 --desc 'CLI Tool for running security tools to send data to a Kiln stack' --license MIT --version $CARGO_MAKE_CRATE_VERSION kiln-cli-$CARGO_MAKE_CRATE_VERSION",
+	"../utils/rpm-builder/target/release/rpm-builder --exec-file target/x86_64-unknown-linux-musl/release/kiln-cli:/usr/bin/kiln-cli --compression gzip --arch x86_64 --desc 'CLI Tool for running security tools to send data to a Kiln stack' --license MIT --version $CARGO_MAKE_CRATE_VERSION kiln-cli-$CARGO_MAKE_CRATE_VERSION.x86_64",
 ]
 
 [tasks.move-rpm]


### PR DESCRIPTION
# What does this PR change?
- Ensures that RPMs that are built include the architecture that they're built for

# Why is it important?
- End user clarity

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
