### PR TITLE
Cli offline switch

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -101,9 +101,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let matches = App::new("Kiln CLI")
         .setting(AppSettings::SubcommandRequired)
         .version(clap::crate_version!())
-        .arg(Arg::with_name("use-local-image")
-            .long("use-local-image")
-            .help("Do not try and pull the latest version of a tool image. Useful for development and scanning without network access"))
+        .arg(Arg::with_name("offline")
+            .long("offline")
+            .help("Do not make any network requests to pull images or update scanning databases etc"))
         .arg(Arg::with_name("tool-image-name")
             .long("tool-image-name")
             .takes_value(true)
@@ -116,7 +116,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             )
         ).get_matches();
 
-    let use_local_image = matches.is_present("use-local-image");
+    let offline = matches.is_present("offline");
 
     let mut env_vec = Vec::new();
     let mut env_app_name = "APP_NAME=".to_string();
@@ -185,7 +185,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     tool_image_repo.to_owned(),
                     tool_image_name.to_owned(),
                     tool_image_tag.to_owned(),
-                    use_local_image,
+                    offline,
                 )
                 .await?;
 
@@ -506,13 +506,13 @@ async fn prepare_tool_image(
     tool_image_repo: String,
     tool_image_name: String,
     tool_image_tag: String,
-    use_local_image: bool,
+    offline: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let docker = Docker::connect_with_local_defaults()?;
     let tool_image_name_full =
         format!("{}/{}:{}", tool_image_repo, tool_image_name, tool_image_tag);
 
-    if use_local_image {
+    if offline {
         let mut filters = HashMap::new();
         filters.insert("reference", vec![tool_image_name_full.as_ref()]);
         let options = Some(ListImagesOptions {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,6 +122,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut env_app_name = "APP_NAME=".to_string();
     let mut env_scan_env = "SCAN_ENV=".to_string();
     let mut env_df_url = "DATA_COLLECTOR_URL=".to_string();
+    let env_offline = format!("OFFLINE={}", offline).to_string();
 
     match parse_kiln_toml_file() {
         Err(e) => {
@@ -141,6 +142,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             env_vec.push(env_df_url);
             env_vec.push(env_app_name);
             env_vec.push(env_scan_env);
+            env_vec.push(env_offline);
         }
     };
 


### PR DESCRIPTION
# What does this PR change?
- Renames the use-local-image CLI switch to a more general offline switch
- Passes an OFFLINE env var to tool containers

# Why is it important?
- Allows tool scans to occur without network access

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
