### PR TITLE
Ruby-dependencies: Enable offline scanning

### DIFF
--- a/tool-images/ruby/bundler-audit/entrypoint.sh
+++ b/tool-images/ruby/bundler-audit/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 START_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
-bundle audit check --update | tee tool-output.txt 
+if [[ $OFFLINE == true ]]; then
+    bundle audit check | tee tool-output.txt
+else
+    bundle audit check --update | tee tool-output.txt 
+fi
 END_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
 
 /data-forwarder --tool-name=bundler-audit --tool-version=0.6.1 --tool-output-path=tool-output.txt --start-time="$START_TIME" --end-time="$END_TIME" --output-format=PlainText --scan-env="$SCAN_ENV" --app-name="$APP_NAME" --endpoint-url="$DATA_COLLECTOR_URL"


### PR DESCRIPTION
# What does this PR change?
- Adds check for offline flag and will not update bundler-audit DB if flag set

# Why is it important?
- Enables offline scanning

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
