### PR TITLE
Remove master terminology from docker image names

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,8 +1,8 @@
-name: Build Master Docker Images
+name: Build Git Docker Images
 on:
     push:
         branches:
-            - master
+            - git
 
 jobs:
     data-collector:
@@ -30,7 +30,7 @@ jobs:
                 path: data-collector/target
                 key: ${{ runner.os }}-cargo-build-target-musl-${{ hashFiles('data-collector/Cargo.lock') }}
             - name: Build
-              run: cargo make build-data-collector-master-docker
+              run: cargo make build-data-collector-git-docker
               working-directory: data-collector/
             - name: docker login
               uses: azure/docker-login@v1
@@ -38,10 +38,10 @@ jobs:
                 password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
                 username: kilnautomation
             - name: Docker push version
-              run: cargo make push-data-collector-docker-master-version
+              run: cargo make push-data-collector-docker-git-version
               working-directory: data-collector/
             - name: Docker push latest
-              run: cargo make push-data-collector-docker-master-latest
+              run: cargo make push-data-collector-docker-git-latest
               working-directory: data-collector/
     data-forwarder:
         name: Data-forwarder build
@@ -91,7 +91,7 @@ jobs:
                 name: data-forwarder
                 path: tool-images/ruby/bundler-audit/
             - name: Build bundler-audit
-              run: cargo make build-bundler-audit-master-docker
+              run: cargo make build-bundler-audit-git-docker
               working-directory: tool-images/ruby/bundler-audit
             - name: docker login
               uses: azure/docker-login@v1
@@ -99,10 +99,10 @@ jobs:
                 password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
                 username: kilnautomation
             - name: Docker push version
-              run: cargo make bundler-audit-docker-push-master-version
+              run: cargo make bundler-audit-docker-push-git-version
               working-directory: tool-images/ruby/bundler-audit
             - name: Docker push latest
-              run: cargo make bundler-audit-docker-push-master-latest
+              run: cargo make bundler-audit-docker-push-git-latest
               working-directory: tool-images/ruby/bundler-audit
     report-parser:
         name: Report-parser build
@@ -129,7 +129,7 @@ jobs:
                 path: report-parser/target
                 key: ${{ runner.os }}-cargo-build-target-musl-${{ hashFiles('report-parser/Cargo.lock') }}
             - name: Build
-              run: cargo make build-report-parser-master-docker
+              run: cargo make build-report-parser-git-docker
               working-directory: report-parser/
             - name: docker login
               uses: azure/docker-login@v1
@@ -137,10 +137,10 @@ jobs:
                 password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
                 username: kilnautomation
             - name: Docker push version
-              run: cargo make push-report-parser-docker-master-version
+              run: cargo make push-report-parser-docker-git-version
               working-directory: report-parser/
             - name: Docker push latest
-              run: cargo make push-report-parser-docker-master-latest
+              run: cargo make push-report-parser-docker-git-latest
               working-directory: report-parser/
     slack-connector:
         name: Slack-connector build
@@ -167,7 +167,7 @@ jobs:
                 path: slack-connector/target
                 key: ${{ runner.os }}-cargo-build-target-musl-${{ hashFiles('slack-connector/Cargo.lock') }}
             - name: Build
-              run: cargo make build-slack-connector-master-docker
+              run: cargo make build-slack-connector-git-docker
               working-directory: slack-connector/
             - name: docker login
               uses: azure/docker-login@v1
@@ -175,8 +175,8 @@ jobs:
                 password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
                 username: kilnautomation
             - name: Docker push version
-              run: cargo make push-slack-connector-docker-master-version
+              run: cargo make push-slack-connector-docker-git-version
               working-directory: slack-connector/
             - name: Docker push latest
-              run: cargo make push-slack-connector-docker-master-latest
+              run: cargo make push-slack-connector-docker-git-latest
               working-directory: slack-connector/

--- a/data-collector/Makefile.toml
+++ b/data-collector/Makefile.toml
@@ -26,24 +26,24 @@ script = [
 command = "docker"
 args = ["build", "-t", "kiln/data-collector:${GIT_BRANCH}-${GIT_SHA}", "."]
 
-[tasks.build-data-collector-master-docker]
-dependencies = ["musl-build", "build-data-collector-docker-tag-master-version", "build-data-collector-docker-tag-master-latest"]
+[tasks.build-data-collector-git-docker]
+dependencies = ["musl-build", "build-data-collector-docker-tag-git-version", "build-data-collector-docker-tag-git-latest"]
 
-[tasks.build-data-collector-docker-tag-master-version]
+[tasks.build-data-collector-docker-tag-git-version]
 command = "docker"
-args = ["build", "-t", "kiln/data-collector:master-${GIT_SHA}", "."]
+args = ["build", "-t", "kiln/data-collector:git-${GIT_SHA}", "."]
 
-[tasks.push-data-collector-docker-master-version]
+[tasks.push-data-collector-docker-git-version]
 command = "docker"
-args = ["push", "kiln/data-collector:master-${GIT_SHA}"]
+args = ["push", "kiln/data-collector:git-${GIT_SHA}"]
 
-[tasks.build-data-collector-docker-tag-master-latest]
+[tasks.build-data-collector-docker-tag-git-latest]
 command = "docker"
-args = ["tag", "kiln/data-collector:master-${GIT_SHA}", "kiln/data-collector:master-latest"]
+args = ["tag", "kiln/data-collector:git-${GIT_SHA}", "kiln/data-collector:git-latest"]
 
-[tasks.push-data-collector-docker-master-latest]
+[tasks.push-data-collector-docker-git-latest]
 command = "docker"
-args = ["push", "kiln/data-collector:master-latest"]
+args = ["push", "kiln/data-collector:git-latest"]
 
 [tasks.build-data-collector-release-docker]
 dependencies = ["musl-build", "build-data-collector-docker-tag-release-version", "build-data-collector-docker-tag-release-latest"]

--- a/report-parser/Makefile.toml
+++ b/report-parser/Makefile.toml
@@ -26,24 +26,24 @@ script = [
 command = "docker"
 args = ["build", "-t", "kiln/report-parser:${GIT_BRANCH}-${GIT_SHA}", "."]
 
-[tasks.build-report-parser-master-docker]
-dependencies = ["musl-build", "build-report-parser-docker-tag-master-version", "build-report-parser-docker-tag-master-latest"]
+[tasks.build-report-parser-git-docker]
+dependencies = ["musl-build", "build-report-parser-docker-tag-git-version", "build-report-parser-docker-tag-git-latest"]
 
-[tasks.build-report-parser-docker-tag-master-version]
+[tasks.build-report-parser-docker-tag-git-version]
 command = "docker"
-args = ["build", "-t", "kiln/report-parser:master-${GIT_SHA}", "."]
+args = ["build", "-t", "kiln/report-parser:git-${GIT_SHA}", "."]
 
-[tasks.push-report-parser-docker-master-version]
+[tasks.push-report-parser-docker-git-version]
 command = "docker"
-args = ["push", "kiln/report-parser:master-${GIT_SHA}"]
+args = ["push", "kiln/report-parser:git-${GIT_SHA}"]
 
-[tasks.build-report-parser-docker-tag-master-latest]
+[tasks.build-report-parser-docker-tag-git-latest]
 command = "docker"
-args = ["tag", "kiln/report-parser:master-${GIT_SHA}", "kiln/report-parser:master-latest"]
+args = ["tag", "kiln/report-parser:git-${GIT_SHA}", "kiln/report-parser:git-latest"]
 
-[tasks.push-report-parser-docker-master-latest]
+[tasks.push-report-parser-docker-git-latest]
 command = "docker"
-args = ["push", "kiln/report-parser:master-latest"]
+args = ["push", "kiln/report-parser:git-latest"]
 
 [tasks.build-report-parser-release-docker]
 dependencies = ["musl-build", "build-report-parser-docker-tag-release-version", "build-report-parser-docker-tag-release-latest"]

--- a/slack-connector/Makefile.toml
+++ b/slack-connector/Makefile.toml
@@ -26,24 +26,24 @@ script = [
 command = "docker"
 args = ["build", "-t", "kiln/slack-connector:${GIT_BRANCH}-${GIT_SHA}", "."]
 
-[tasks.build-slack-connector-master-docker]
-dependencies = ["musl-build", "build-slack-connector-docker-tag-master-version", "build-slack-connector-docker-tag-master-latest"]
+[tasks.build-slack-connector-git-docker]
+dependencies = ["musl-build", "build-slack-connector-docker-tag-git-version", "build-slack-connector-docker-tag-git-latest"]
 
-[tasks.build-slack-connector-docker-tag-master-version]
+[tasks.build-slack-connector-docker-tag-git-version]
 command = "docker"
-args = ["build", "-t", "kiln/slack-connector:master-${GIT_SHA}", "."]
+args = ["build", "-t", "kiln/slack-connector:git-${GIT_SHA}", "."]
 
-[tasks.push-slack-connector-docker-master-version]
+[tasks.push-slack-connector-docker-git-version]
 command = "docker"
-args = ["push", "kiln/slack-connector:master-${GIT_SHA}"]
+args = ["push", "kiln/slack-connector:git-${GIT_SHA}"]
 
-[tasks.build-slack-connector-docker-tag-master-latest]
+[tasks.build-slack-connector-docker-tag-git-latest]
 command = "docker"
-args = ["tag", "kiln/slack-connector:master-${GIT_SHA}", "kiln/slack-connector:master-latest"]
+args = ["tag", "kiln/slack-connector:git-${GIT_SHA}", "kiln/slack-connector:git-latest"]
 
-[tasks.push-slack-connector-docker-master-latest]
+[tasks.push-slack-connector-docker-git-latest]
 command = "docker"
-args = ["push", "kiln/slack-connector:master-latest"]
+args = ["push", "kiln/slack-connector:git-latest"]
 
 [tasks.build-slack-connector-release-docker]
 dependencies = ["musl-build", "build-slack-connector-docker-tag-release-version", "build-slack-connector-docker-tag-release-latest"]

--- a/tool-images/ruby/bundler-audit/Makefile.toml
+++ b/tool-images/ruby/bundler-audit/Makefile.toml
@@ -15,24 +15,24 @@ args = ["data-forwarder"]
 command = "docker"
 args = ["build", "-t", "kiln/bundler-audit:${GIT_BRANCH}-${GIT_SHA}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
 
-[tasks.build-bundler-audit-master-docker]
-dependencies = ["build-bundler-audit-docker-tag-master-version", "build-bundler-audit-docker-tag-master-latest"]
+[tasks.build-bundler-audit-git-docker]
+dependencies = ["build-bundler-audit-docker-tag-git-version", "build-bundler-audit-docker-tag-git-latest"]
 
-[tasks.build-bundler-audit-docker-tag-master-version]
+[tasks.build-bundler-audit-docker-tag-git-version]
 command = "docker"
-args = ["build", "-t", "kiln/bundler-audit:master-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
+args = ["build", "-t", "kiln/bundler-audit:git-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
 
-[tasks.bundler-audit-docker-push-master-version]
+[tasks.bundler-audit-docker-push-git-version]
 command = "docker"
-args = ["push", "kiln/bundler-audit:master-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}"]
+args = ["push", "kiln/bundler-audit:git-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}"]
 
-[tasks.build-bundler-audit-docker-tag-master-latest]
+[tasks.build-bundler-audit-docker-tag-git-latest]
 command = "docker"
-args = ["tag", "kiln/bundler-audit:master-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}", "kiln/bundler-audit:master-latest"]
+args = ["tag", "kiln/bundler-audit:git-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}", "kiln/bundler-audit:git-latest"]
 
-[tasks.bundler-audit-docker-push-master-latest]
+[tasks.bundler-audit-docker-push-git-latest]
 command = "docker"
-args = ["push", "kiln/bundler-audit:master-latest"]
+args = ["push", "kiln/bundler-audit:git-latest"]
 
 [tasks.build-bundler-audit-release-docker]
 dependencies = ["build-bundler-audit-docker-tag-release-version", "build-bundler-audit-docker-tag-release-latest"]


### PR DESCRIPTION
# What does this PR change?
- Updates the names used in docker images to indicate they're from the git repo default branch to use `git`

# Why is it important?
- Because there's no reason to use a term of oppression

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
