### PR TITLE
Docs: Update repo analyser script in data analysis docs to use offline flag when calling Kiln CLI

### DIFF
--- a/docs/data-analysis/repo-analyser/repo-analyser.py
+++ b/docs/data-analysis/repo-analyser/repo-analyser.py
@@ -38,7 +38,7 @@ for commit in all_commits:
         f.writelines([f'app_name="{app_name}"\n', 'data_collector_url="{url}"'])
         f.flush()
     try:
-        subprocess.check_output(["kiln-cli", "--use-local-image", "ruby", "dependencies"], cwd=proj_dir)
+        subprocess.check_output(["kiln-cli", "--offline", "ruby", "dependencies"], cwd=proj_dir)
     except subprocess.CalledProcessError as err:
         print("Something went wrong when running Kiln on commit ", rev.id)
         raise

--- a/docs/data-analysis/repo-analyser/repo-analyser.py
+++ b/docs/data-analysis/repo-analyser/repo-analyser.py
@@ -40,5 +40,5 @@ for commit in all_commits:
     try:
         subprocess.check_output(["kiln-cli", "--offline", "ruby", "dependencies"], cwd=proj_dir)
     except subprocess.CalledProcessError as err:
-        print("Something went wrong when running Kiln on commit ", rev.id)
+        print("Something went wrong when running Kiln on commit ", commit.id)
         raise


### PR DESCRIPTION
# What does this PR change?
- Fixed how repo_analyser.py calls kiln-cli
- Fixed use of non-existent variable when printing error message

# Why is it important?
- Working documentation

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
