### PR TITLE
Bundler-audit: Add dependency to docker build target

### DIFF
--- a/tool-images/ruby/bundler-audit/Makefile.toml
+++ b/tool-images/ruby/bundler-audit/Makefile.toml
@@ -12,6 +12,7 @@ command = "rm"
 args = ["data-forwarder"]
 
 [tasks.build-bundler-audit-docker]
+dependencies = ["pre-build-bundler-audit-docker"]
 command = "docker"
 args = ["build", "-t", "kiln/bundler-audit:${GIT_BRANCH}-${GIT_SHA}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
 


### PR DESCRIPTION
# What does this PR change?
- Update bundler-audit tool makefile to ensure data-forwarder binary has been copied to correct location before building

# Why is it important?
- Makes sure top level `cargo make tools` is using the fresh data-forwarder binary

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
