### PR TITLE
Parameterise base images

### DIFF
--- a/data-collector/Dockerfile
+++ b/data-collector/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.10
+ARG BASE_IMAGE=alpine:3.10
+FROM $BASE_IMAGE
 WORKDIR /app
 RUN apk add --no-cache ca-certificates su-exec
 COPY entrypoint.sh /app

--- a/report-parser/Dockerfile
+++ b/report-parser/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.10
+ARG BASE_IMAGE=alpine:3.10
+FROM $BASE_IMAGE
 WORKDIR /app
 RUN apk add --no-cache ca-certificates su-exec
 COPY entrypoint.sh /app

--- a/slack-connector/Dockerfile
+++ b/slack-connector/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.10
+ARG BASE_IMAGE=alpine:3.10
+FROM $BASE_IMAGE
 WORKDIR /app
 RUN apk add --no-cache ca-certificates su-exec
 COPY entrypoint.sh /app

--- a/tool-images/ruby/bundler-audit/Dockerfile
+++ b/tool-images/ruby/bundler-audit/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:2-alpine
+ARG BASE_IMAGE=ruby:2-alpine
+FROM $BASE_IMAGE
 RUN apk --no-cache add ca-certificates
 RUN apk --no-cache add git
 RUN gem install bundler -v "~>1.0" && \


### PR DESCRIPTION
# What does this PR change?
- Parameterises the base images used when building docker images, defaulting the the previously hard coded base images

# Why is it important?
- Allows users to customise the base image used, if they need to use an internal hardened image when deploying Kiln

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
