### PR TITLE
Replace suexec with gosu

### DIFF
--- a/data-collector/Dockerfile
+++ b/data-collector/Dockerfile
@@ -1,7 +1,23 @@
 ARG BASE_IMAGE=alpine:3.10
 FROM $BASE_IMAGE
 WORKDIR /app
-RUN apk add --no-cache ca-certificates su-exec
+RUN apk add --no-cache ca-certificates
+
+ENV GOSU_VERSION=1.12
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .gosu-deps gnupg curl \
+    && gpg --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && rm -r /root/.gnupg/ \
+    && apk del --no-network .gosu-deps \
+    && chmod +x /usr/local/bin/gosu \
+    # Verify that the binary works
+    && gosu nobody true
+
 COPY entrypoint.sh /app
 RUN chmod +x /app/entrypoint.sh
 RUN addgroup -S kilngroup && adduser -S kilnapp -G kilngroup 

--- a/data-collector/entrypoint.sh
+++ b/data-collector/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cp /tls/* /usr/local/share/ca-certificates
 /usr/sbin/update-ca-certificates
-su-exec kilnapp:kilngroup /app/data-collector
+gosu kilnapp:kilngroup /app/data-collector

--- a/report-parser/Dockerfile
+++ b/report-parser/Dockerfile
@@ -1,7 +1,23 @@
 ARG BASE_IMAGE=alpine:3.10
 FROM $BASE_IMAGE
 WORKDIR /app
-RUN apk add --no-cache ca-certificates su-exec
+RUN apk add --no-cache ca-certificates
+
+ENV GOSU_VERSION=1.12
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .gosu-deps gnupg curl \
+    && gpg --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && rm -r /root/.gnupg/ \
+    && apk del --no-network .gosu-deps \
+    && chmod +x /usr/local/bin/gosu \
+    # Verify that the binary works
+    && gosu nobody true
+
 COPY entrypoint.sh /app
 RUN chmod +x /app/entrypoint.sh
 RUN addgroup -S kilngroup && adduser -S kilnapp -G kilngroup 

--- a/report-parser/entrypoint.sh
+++ b/report-parser/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cp /tls/* /usr/local/share/ca-certificates
 /usr/sbin/update-ca-certificates
-su-exec kilnapp:kilngroup /app/report-parser
+gosu kilnapp:kilngroup /app/report-parser

--- a/slack-connector/Dockerfile
+++ b/slack-connector/Dockerfile
@@ -1,7 +1,23 @@
 ARG BASE_IMAGE=alpine:3.10
 FROM $BASE_IMAGE
 WORKDIR /app
-RUN apk add --no-cache ca-certificates su-exec
+RUN apk add --no-cache ca-certificates
+
+ENV GOSU_VERSION=1.12
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .gosu-deps gnupg curl \
+    && gpg --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && rm -r /root/.gnupg/ \
+    && apk del --no-network .gosu-deps \
+    && chmod +x /usr/local/bin/gosu \
+    # Verify that the binary works
+    && gosu nobody true
+
 COPY entrypoint.sh /app
 RUN chmod +x /app/entrypoint.sh
 RUN addgroup -S kilngroup && adduser -S kilnapp -G kilngroup 

--- a/slack-connector/entrypoint.sh
+++ b/slack-connector/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cp /tls/* /usr/local/share/ca-certificates
 /usr/sbin/update-ca-certificates
-su-exec kilnapp:kilngroup /app/slack-connector
+gosu kilnapp:kilngroup /app/slack-connector


### PR DESCRIPTION
# What does this PR change?
- Switches from su-exec to gosu for dropping privileges in container entrypoint

# Why is it important?
- su-exec is only easily available on Alpine. This change makes it easier for other base images to be used without having to change the entrypoint script, although the usage of the apk tool in the Dockerfile will require writing a custom Dockerfile if a non-alpine base image is used

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
