### PR TITLE
Trust store probe components

### DIFF
--- a/data-collector/Cargo.lock
+++ b/data-collector/Cargo.lock
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "kiln_lib"
 version = "0.1.0"
-source = "git+https://github.com/simplybusiness/Kiln?branch=main#c985357e19a070cc2b1062ace3150e36f47e2f0b"
+source = "git+https://github.com/simplybusiness/Kiln?branch=main#c9437bed985446fd303afa871bb4add6c8ec99df"
 dependencies = [
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -922,6 +922,7 @@ dependencies = [
  "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdkafka 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/data-collector/entrypoint.sh
+++ b/data-collector/entrypoint.sh
@@ -3,6 +3,7 @@ if [[ -d /tls ]]; then
     if find /tls/ -mindepth 1 | read; then
         cp /tls/* /usr/local/share/ca-certificates
         /usr/sbin/update-ca-certificates
+        cp /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem
     fi
 fi
 gosu kilnapp:kilngroup /app/data-collector

--- a/data-collector/src/main.rs
+++ b/data-collector/src/main.rs
@@ -8,9 +8,7 @@ use std::boxed::Box;
 use std::convert::TryFrom;
 use std::env;
 use std::error::Error;
-use std::path::PathBuf;
 use std::str;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use log::warn;
@@ -25,12 +23,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     std::env::set_var("RUST_LOG", "info");
     env_logger::init();
 
-    let tls_cert_path = PathBuf::from_str("/etc/ssl/certs/ca-certificates.crt").unwrap();
-
     let config = get_bootstrap_config(&mut env::vars())
         .map_err(|err| failure::err_msg(format!("Configuration Error: {}", err)))?;
 
-    let producer = build_kafka_producer(config, &tls_cert_path)
+    let producer = build_kafka_producer(config)
         .map_err(|err| err_msg(format!("Kafka Error: {}", err.to_string())))?;
 
     let shared_producer = Arc::from(producer);

--- a/report-parser/Cargo.lock
+++ b/report-parser/Cargo.lock
@@ -542,13 +542,14 @@ dependencies = [
 [[package]]
 name = "kiln_lib"
 version = "0.1.0"
-source = "git+https://github.com/simplybusiness/Kiln?branch=main#c985357e19a070cc2b1062ace3150e36f47e2f0b"
+source = "git+https://github.com/simplybusiness/Kiln?branch=main#c9437bed985446fd303afa871bb4add6c8ec99df"
 dependencies = [
  "addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "avro-rs 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdkafka 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/report-parser/entrypoint.sh
+++ b/report-parser/entrypoint.sh
@@ -3,6 +3,7 @@ if [[ -d /tls ]]; then
     if find /tls/ -mindepth 1 | read; then
         cp /tls/* /usr/local/share/ca-certificates
         /usr/sbin/update-ca-certificates
+        cp /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem
     fi
 fi
 gosu kilnapp:kilngroup /app/report-parser

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -32,7 +32,6 @@ use std::convert::TryFrom;
 use std::env;
 use std::error::Error;
 use std::io::Read;
-use std::path::PathBuf;
 use std::str::FromStr;
 use url::Url;
 use uuid::Uuid;
@@ -43,15 +42,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let config = get_bootstrap_config(&mut env::vars())
         .map_err(|err| failure::err_msg(format!("Configuration Error: {}", err)))?;
 
-    let tls_cert_path = PathBuf::from_str("/etc/ssl/certs/ca-certificates.crt").unwrap();
-
     let consumer =
-        build_kafka_consumer(config.clone(), "report-parser".to_string(), &tls_cert_path)
+        build_kafka_consumer(config.clone(), "report-parser".to_string())
             .map_err(|err| err_msg(format!("Kafka Consumer Error: {}", err.to_string())))?;
 
     consumer.subscribe(&["ToolReports"])?;
 
-    let producer = build_kafka_producer(config.clone(), &tls_cert_path)
+    let producer = build_kafka_producer(config.clone())
         .map_err(|err| err_msg(format!("Kafka Producer Error: {}", err.to_string())))?;
 
     let base_url = Url::parse(

--- a/slack-connector/Cargo.lock
+++ b/slack-connector/Cargo.lock
@@ -526,13 +526,14 @@ dependencies = [
 [[package]]
 name = "kiln_lib"
 version = "0.1.0"
-source = "git+https://github.com/simplybusiness/Kiln?branch=main#c985357e19a070cc2b1062ace3150e36f47e2f0b"
+source = "git+https://github.com/simplybusiness/Kiln?branch=main#c9437bed985446fd303afa871bb4add6c8ec99df"
 dependencies = [
  "addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "avro-rs 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdkafka 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/slack-connector/entrypoint.sh
+++ b/slack-connector/entrypoint.sh
@@ -3,6 +3,7 @@ if [[ -d /tls ]]; then
     if find /tls/ -mindepth 1 | read; then
         cp /tls/* /usr/local/share/ca-certificates
         /usr/sbin/update-ca-certificates
+        cp /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem
     fi
 fi
 gosu kilnapp:kilngroup /app/slack-connector

--- a/slack-connector/src/main.rs
+++ b/slack-connector/src/main.rs
@@ -17,8 +17,6 @@ use std::boxed::Box;
 use std::convert::TryFrom;
 use std::env;
 use std::error::Error;
-use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -33,10 +31,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let config = get_bootstrap_config(&mut env::vars())
         .map_err(|err| failure::err_msg(format!("Configuration Error: {}", err)))?;
 
-    let tls_cert_path = PathBuf::from_str("/etc/ssl/certs/ca-certificates.crt").unwrap();
-
     let consumer = Arc::new(
-        build_kafka_consumer(config, "slack-connector".to_string(), &tls_cert_path)
+        build_kafka_consumer(config, "slack-connector".to_string())
             .map_err(|err| err_msg(format!("Kafka Consumer Error: {}", err.to_string())))?,
     );
 


### PR DESCRIPTION
# What does this PR change?
- Updates server components to use kiln_lib trust store probing
- Updates server components entrypoint scripts to ensure both alpine trust stores are updated with certs

# Why is it important?
- Makes server components more portable between distros

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
