### PR TITLE
Docs: Added additional contribution suggestions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ If you're interested in trying Kiln out, there is a [Quickstart](docs/quickstart
 ## Contributing
 Please note that this project is released with a Contributor Code of Conduct. By participating in this project, you agree to abide by its terms. The Code of Conduct can be found [here](CODE_OF_CONDUCT.md).
 
+There are many ways you can contribute to Kiln, and writing Rust is only one of them. You could:
+- Try Kiln out on your own projects and file bug reports
+- Write documentation or raise issues with the documentation
+- Review current test coverage (both unit and integration testing) and raise issues for gaps in coverage
+- Suggest new tools or service connectors
+- Write about interesting ways to use the data Kiln generates
+
 To contribute to Kiln, you'll need the following tools installed:
 - Rust (stable channel, assuming 1.40 as minimum)
 - Clippy (For linting)


### PR DESCRIPTION
# What does this PR change?
- Adds suggestions for ways to contribute to Kiln that don't involve writing Rust

# Why is it important?
- Closes #54 
- Encourages participation from people who aren't comfortable with Rust and in areas of the project people might not think to contribute to

# Checklist
- [ ] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
