### PR TITLE
Fix docker build random failure

### DIFF
--- a/data-collector/Dockerfile
+++ b/data-collector/Dockerfile
@@ -12,7 +12,7 @@ RUN set -eux; \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
     && gpg --verify /usr/local/bin/gosu.asc \
     && rm /usr/local/bin/gosu.asc \
-    && rm -r /root/.gnupg/ \
+    && rm -rf /root/.gnupg/ \
     && apk del --no-network .gosu-deps \
     && chmod +x /usr/local/bin/gosu \
     # Verify that the binary works

--- a/report-parser/Dockerfile
+++ b/report-parser/Dockerfile
@@ -12,7 +12,7 @@ RUN set -eux; \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
     && gpg --verify /usr/local/bin/gosu.asc \
     && rm /usr/local/bin/gosu.asc \
-    && rm -r /root/.gnupg/ \
+    && rm -rf /root/.gnupg/ \
     && apk del --no-network .gosu-deps \
     && chmod +x /usr/local/bin/gosu \
     # Verify that the binary works

--- a/slack-connector/Dockerfile
+++ b/slack-connector/Dockerfile
@@ -12,7 +12,7 @@ RUN set -eux; \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
     && gpg --verify /usr/local/bin/gosu.asc \
     && rm /usr/local/bin/gosu.asc \
-    && rm -r /root/.gnupg/ \
+    && rm -rf /root/.gnupg/ \
     && apk del --no-network .gosu-deps \
     && chmod +x /usr/local/bin/gosu \
     # Verify that the binary works


### PR DESCRIPTION
# What does this PR change?
- Occasionally during docker image builds, the build will fail while cleaning up the gnupg directory created during gosu installation (Example: https://github.com/simplybusiness/Kiln/runs/793283512?check_suite_focus=true). This PR fixes that.

# Why is it important?
- Build stability

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
