### PR TITLE
Bundler-audit: Use unique file name in bundler-audit tool run

### DIFF
--- a/tool-images/ruby/bundler-audit/entrypoint.sh
+++ b/tool-images/ruby/bundler-audit/entrypoint.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 START_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
+FILE_NAME=$(mktemp -t ./tool-output)
 if [[ $OFFLINE == true ]]; then
-    bundle audit check | tee tool-output.txt
+    bundle audit check | tee $FILE_NAME
 else
-    bundle audit check --update | tee tool-output.txt 
+    bundle audit check --update | tee $FILE_NAME
 fi
 END_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
 
-/data-forwarder --tool-name=bundler-audit --tool-version=0.6.1 --tool-output-path=tool-output.txt --start-time="$START_TIME" --end-time="$END_TIME" --output-format=PlainText --scan-env="$SCAN_ENV" --app-name="$APP_NAME" --endpoint-url="$DATA_COLLECTOR_URL"
+/data-forwarder --tool-name=bundler-audit --tool-version=0.6.1 --tool-output-path="$FILE_NAME" --start-time="$START_TIME" --end-time="$END_TIME" --output-format=PlainText --scan-env="$SCAN_ENV" --app-name="$APP_NAME" --endpoint-url="$DATA_COLLECTOR_URL"
 
-rm tool-output.txt
+rm $FILE_NAME 


### PR DESCRIPTION
# What does this PR change?
- Ensure we're using a unique filename to temporarily store tool output when running bundler audit

# Why is it important?
- Allows one host to run multiple concurrent instances of bundler audit through Kiln without running into data races with tool-output.txt

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
