### PR TITLE
Kiln_lib: Add impl of ResponseError for ValidationErrors

### DIFF
--- a/kiln_lib/src/validation.rs
+++ b/kiln_lib/src/validation.rs
@@ -630,8 +630,28 @@ impl ValidationError {
 use actix_web::HttpResponse;
 
 #[cfg(feature = "web")]
+use actix_web::dev::Body;
+
+#[cfg(feature = "web")]
+use actix_web::error::ResponseError;
+
+#[cfg(feature = "web")]
+use actix_web::http::StatusCode;
+
+#[cfg(feature = "web")]
 impl Into<HttpResponse> for ValidationError {
     fn into(self) -> HttpResponse {
+        HttpResponse::BadRequest().json(self)
+    }
+}
+
+#[cfg(feature = "web")]
+impl actix_web::ResponseError for ValidationError {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::BAD_REQUEST
+    }
+
+    fn error_response(&self) -> HttpResponse<Body> {
         HttpResponse::BadRequest().json(self)
     }
 }


### PR DESCRIPTION
# What does this PR change?
- Adds an impl of the actix_web::ResponseError trait for ValidationErrors behind the web feature

# Why is it important?
Simplifies error handling in DataCollector by allowing us to return a ValidationError from the handler directly, instead of having to wrap it in a failure struct to return something implementing that trait

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
