### PR TITLE
Data-collector: Tracing fields

### DIFF
--- a/data-collector/Cargo.lock
+++ b/data-collector/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/data-collector/Cargo.toml
+++ b/data-collector/Cargo.toml
@@ -24,6 +24,7 @@ slog-json = { version = "2.3", features = ["nested-values"] }
 slog-async = { version = "2.5", features = ["nested-values"] }
 slog_derive = "0.2"
 erased-serde = "0.3"
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
 serial_test = "0.1"

--- a/data-collector/src/lib.rs
+++ b/data-collector/src/lib.rs
@@ -131,8 +131,9 @@ where
                 let mut req_extensions = req_http.extensions_mut();
                 req_extensions.insert(transaction_id);
             }
-            req = ServiceRequest::from_parts(req_http, req_payload)
-                .map_err(|_| failure::err_msg("Unable to reconstitute request after attaching transaction id"))?;
+            req = ServiceRequest::from_parts(req_http, req_payload).map_err(|_| {
+                failure::err_msg("Unable to reconstitute request after attaching transaction id")
+            })?;
 
             // read request body
             let mut stream = req.take_payload();


### PR DESCRIPTION
# What does this PR change?
* Adds event.id to log output to uniquely identify a log line
* Adds transaction.id to log output to group log lines for a specific request together
* Adds transaction id to request extensions for further logging if needed

Note: Event and Transaction IDs are UUIDv4 formatted as hyphenated, lower hex encoded strings

# Why is it important?
* Enables easier debugging of issues and gives operators the ability to uniquely identify logs

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
