### PR TITLE
Image versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,8 @@ Kiln is still in it's early stages and isn't ready for production use. However, 
 ## Versioning
 Kiln follows [SemVer 2.0](https://semver.org/) for versioning and all components are versioned in lockstep.
 
-Our Docker images follow this naming convention:
+Docker images use two sets of tags: git-$VERSION and $VERSION. The former is used for images built after a merge to the main branch, the latter is used for released versions of Kiln. Previously, images for tools also included the version of the tool in the image tag, but tool upgrades will now be handled in the same way as other Kiln updates using the semver tag.
 
-| /        | Main                                    | Release                             |
-| ---      | -------                                 | ---------                           |
-| Tool     | kiln/tool-name:git-GIT_SHA-TOOL_VERSION | kiln/tool-name:GIT_TAG-TOOL_VERSION |
-| Not Tool | kiln/component-name:git-GIT_SHA         | kiln/component-name:GIT_TAG         |
+When a version is released, it will also overwrite the less specific semver compatible tags. For example, in the 0.2 series, if version 0.2.1 was released, this would also overwrite the 0.2 and latest tags.
 
-The kiln/tool-name:git-latest, kiln/component-name:git-latest, kiln/tool-name:latest and kiln/component-name:latest are updated to point at the most recently published image for that channel.
+The CLI will attempt to pull and use the latest semver comptaible image for a given tool.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -164,7 +164,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     }
                     Some(name) => name.into(),
                 };
-                let image_name_regex = Regex::new(r#"(?:(?P<r>[a-zA-Z0-9_-]+)/)?(?P<i>[a-zA-Z0-9_-]+)(?::(?P<t>[a-zA-Z0-9_-]+))?"#).unwrap();
+                let image_name_regex = Regex::new(r#"(?:(?P<r>[a-zA-Z0-9_-]+)/)?(?P<i>[a-zA-Z0-9_-]+)(?::(?P<t>[a-zA-Z0-9_.-]+))?"#).unwrap();
                 let image_name_matches = image_name_regex.captures(&tool_image).expect(
                     "Error parsing tool image name, ensure name is in format REPO/IMAGE:TAG",
                 );

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -419,7 +419,7 @@ pub async fn get_fs_layers_for_docker_image(
         .request(Method::GET, &docker_manifest_url)
         .bearer_auth(token)
         .build()?;
-    let manifest_resp = client.execute(manifest_req).await?;
+    let manifest_resp = client.execute(manifest_req).await?.error_for_status().expect(&format!("Could not get information about docker image {}/{}:{}. Check that image exists", repo_name, image_name, tag));
     let manifest_resp_body: Value = manifest_resp.json().await?;
 
     let layers = manifest_resp_body["fsLayers"]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -157,10 +157,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             Some("dependencies") => {
                 let tool_image = match matches.value_of("tool-image-name") {
                     None => {
-                        let tag = get_tag_for_image("kiln".into(), "bundler-audit".into()).await.expect("Could not get tag for bundler-audit image");
+                        let tag = get_tag_for_image("kiln".into(), "bundler-audit".into())
+                            .await
+                            .expect("Could not get tag for bundler-audit image");
                         format!("kiln/bundler-audit:{}", tag)
-                    },
-                    Some(name) => name.into()
+                    }
+                    Some(name) => name.into(),
                 };
                 let image_name_regex = Regex::new(r#"(?:(?P<r>[a-zA-Z0-9_-]+)/)?(?P<i>[a-zA-Z0-9_-]+)(?::(?P<t>[a-zA-Z0-9_-]+))?"#).unwrap();
                 let image_name_matches = image_name_regex.captures(&tool_image).expect(

--- a/tool-images/ruby/bundler-audit/Dockerfile
+++ b/tool-images/ruby/bundler-audit/Dockerfile
@@ -11,7 +11,6 @@ RUN ["chmod", "+x", "/entrypoint.sh"]
 COPY data-forwarder /data-forwarder
 RUN ["chmod", "+x", "/data-forwarder"]
 
-ARG BUNDLER_AUDIT_VERSION
-RUN gem install bundler-audit -v $BUNDLER_AUDIT_VERSION
+RUN gem install bundler-audit -v 0.6.1
 RUN bundler audit update
 CMD ["/entrypoint.sh"]

--- a/tool-images/ruby/bundler-audit/Makefile.toml
+++ b/tool-images/ruby/bundler-audit/Makefile.toml
@@ -1,7 +1,6 @@
 [env]
 GIT_SHA = { script = ["git rev-parse --short HEAD"] }
 GIT_BRANCH = { script = ["git rev-parse --abbrev-ref HEAD"] }
-TOOL_VERSION_BUNDLER_AUDIT="0.6.1"
 
 [tasks.pre-build-bundler-audit-docker]
 command = "cp"
@@ -14,22 +13,22 @@ args = ["data-forwarder"]
 [tasks.build-bundler-audit-docker]
 dependencies = ["pre-build-bundler-audit-docker"]
 command = "docker"
-args = ["build", "-t", "kiln/bundler-audit:${GIT_BRANCH}-${GIT_SHA}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
+args = ["build", "-t", "kiln/bundler-audit:${GIT_BRANCH}-${GIT_SHA}", "."]
 
 [tasks.build-bundler-audit-git-docker]
 dependencies = ["build-bundler-audit-docker-tag-git-version", "build-bundler-audit-docker-tag-git-latest"]
 
 [tasks.build-bundler-audit-docker-tag-git-version]
 command = "docker"
-args = ["build", "-t", "kiln/bundler-audit:git-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}", "--build-arg", "BUNDLER_AUDIT_VERSION=${TOOL_VERSION_BUNDLER_AUDIT}", "."]
+args = ["build", "-t", "kiln/bundler-audit:git-${GIT_SHA}", "."]
 
 [tasks.bundler-audit-docker-push-git-version]
 command = "docker"
-args = ["push", "kiln/bundler-audit:git-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}"]
+args = ["push", "kiln/bundler-audit:git-${GIT_SHA}"]
 
 [tasks.build-bundler-audit-docker-tag-git-latest]
 command = "docker"
-args = ["tag", "kiln/bundler-audit:git-${GIT_SHA}-${TOOL_VERSION_BUNDLER_AUDIT}", "kiln/bundler-audit:git-latest"]
+args = ["tag", "kiln/bundler-audit:git-${GIT_SHA}", "kiln/bundler-audit:git-latest"]
 
 [tasks.bundler-audit-docker-push-git-latest]
 command = "docker"
@@ -41,19 +40,19 @@ dependencies = ["build-bundler-audit-docker-tag-release-version", "build-bundler
 [tasks.build-bundler-audit-docker-tag-release-version]
 script = [
 	"GIT_TAG=git rev-parse --abbrev-ref HEAD",
-	"docker build -t kiln/bundler-audit:$GIT_TAG-$TOOL_VERSION_BUNDLER_AUDIT --build-arg BUNDLER_AUDIT_VERSION=$TOOL_VERSION_BUNDLER_AUDIT ."
+	"docker build -t kiln/bundler-audit:$GIT_TAG ."
 ]
 
 [tasks.bundler-audit-docker-push-release-version]
 script = [
 	"GIT_TAG=git rev-parse --abbrev-ref HEAD",
-	"docker push kiln/bundler-audit:$GIT_TAG-$TOOL_VERSION_BUNDLER_AUDIT"
+	"docker push kiln/bundler-audit:$GIT_TAG"
 ]
 
 [tasks.build-bundler-audit-docker-tag-release-latest]
 script = [
 	"GIT_TAG=git rev-parse --abbrev-ref HEAD",
-	"docker tag kiln/bundler-audit:$GIT_TAG-$TOOL_VERSION_BUNDLER_AUDIT kiln/bundler-audit:latest"
+	"docker tag kiln/bundler-audit:$GIT_TAG kiln/bundler-audit:latest"
 ]
 
 [tasks.bundler-audit-docker-push-release-latest]


### PR DESCRIPTION
# What does this PR change?
- Updates project README to use new simplified docker image versioning scheme
- Removes tool version number from bundler-audit images
- Updates CLI to use git-latest tag for tool images by default when built in debug mode, otherwise it uses a tag with the same version number as the CLI binary

# Why is it important?
- Prevents Kiln users from using new tool images with possible breaking changes in them

# Checklist
- [ ] Tests added/updated as appropriate
- [x] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
