### PR TITLE
Python safety

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.server-components]
 dependencies = [
-    "build-data-collector-git-docker",
+	"build-data-collector-git-docker",
 	"build-report-parser-git-docker",
 	"build-slack-connector-git-docker"
 ]
@@ -8,7 +8,8 @@ dependencies = [
 [tasks.tools]
 dependencies = [
 	"build-data-forwarder-musl",
-	"build-bundler-audit-docker"
+	"build-bundler-audit-docker",
+	"build-safety-docker"
 ]
 
 [tasks.cli]
@@ -34,3 +35,7 @@ args = ["make", "--cwd", "data-forwarder", "build-data-forwarder-musl"]
 [tasks.build-bundler-audit-docker]
 command = "cargo"
 args = ["make", "--cwd", "tool-images/ruby/bundler-audit", "build-bundler-audit-docker"]
+
+[tasks.build-safety-docker]
+command = "cargo"
+args = ["make", "--cwd", "tool-images/python/safety", "build-safety-docker"]

--- a/report-parser/Cargo.lock
+++ b/report-parser/Cargo.lock
@@ -15,16 +15,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler32"
-version = "1.0.4"
+name = "addr2line"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+
+[[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.10"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -88,12 +103,15 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "1.4.3"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
+checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
 dependencies = [
+ "async-channel",
  "async-executor",
  "async-io",
+ "async-mutex",
+ "blocking",
  "futures-lite",
  "num_cpus",
  "once_cell",
@@ -101,22 +119,31 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0529565cae1f732d469f06fedff0f75d0e27eb22129ddf5707cef8bd7a2cfe"
+checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "libc",
  "log",
+ "nb-connect",
  "once_cell",
  "parking",
  "polling",
  "vec-arena",
  "waker-fn",
- "wepoll-sys-stjepang",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+dependencies = [
+ "event-listener",
 ]
 
 [[package]]
@@ -126,6 +153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb901c30ebc2fc4ab46395bbfbdba9542c16559d853645d75190c3056caf3bc"
+dependencies = [
+ "async-std",
 ]
 
 [[package]]
@@ -146,17 +182,16 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f84f1280a2b436a2c77c2582602732b6c2f4321d5494d6e799e6c367859a8"
+checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
 dependencies = [
  "async-channel",
  "async-global-executor",
  "async-io",
- "async-mutex",
+ "async-lock",
  "async-process",
- "blocking",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -186,7 +221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -209,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "avro-rs"
@@ -229,31 +264,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.46"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
+checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
 dependencies = [
- "backtrace-sys",
- "cfg-if 0.1.10",
+ "addr2line",
+ "cfg-if 1.0.0",
  "libc",
+ "miniz_oxide",
+ "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -320,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.1"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byteorder"
@@ -332,9 +353,15 @@ checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cache-padded"
@@ -344,9 +371,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.52"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -362,21 +389,23 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.11"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "cmake"
-version = "0.1.42"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
 dependencies = [
  "cc",
 ]
@@ -407,9 +436,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -417,27 +446,17 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crc32fast"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -447,18 +466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.2",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -481,11 +489,11 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "ctor"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
+checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -522,18 +530,18 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.2.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c0346158a19b3627234e15596f5e465c360fcdb97d817bcb255e0510f5a788"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derivative"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -570,12 +578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,27 +594,27 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.22"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "erased-serde"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca8b296792113e1500fd935ae487be6e00ce318952a6880555554824d6ebf38"
+checksum = "0465971a8cc1fa2455c8465aaa377131e1f1cf4983280f474a13e68793aa770c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "error-chain"
-version = "0.12.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "backtrace",
  "version_check",
@@ -632,15 +634,15 @@ checksum = "f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
 [[package]]
 name = "failure"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -648,12 +650,12 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
  "synstructure",
 ]
@@ -675,21 +677,33 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.14"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
  "miniz_oxide",
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.6"
+name = "flume"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "531a685ab99b8f60a271b44d5dd1a76e55124a8c9fa0407b7a8e9cd172d5b588"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "spinning_top",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -705,6 +719,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -730,9 +754,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.4"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -761,9 +785,9 @@ checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.4"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -799,7 +823,7 @@ checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -862,14 +886,31 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gimli"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "gloo-timers"
@@ -886,28 +927,35 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377038bf3c89d18d6ca1431e7a5027194fbd724ca10592b9487ede5e8e144f42"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
  "http",
  "indexmap",
- "log",
  "slab",
- "tokio",
+ "tokio 0.2.25",
  "tokio-util",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.11"
+name = "hashbrown"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -923,11 +971,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
@@ -938,15 +986,25 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
+ "http",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+dependencies = [
+ "bytes 1.0.1",
  "http",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
 
 [[package]]
 name = "httpdate"
@@ -956,29 +1014,29 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "httpmock"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e098238acaa95e0bb3fd357317817fde35efb9cdedf74b18b24698499eea9d"
+checksum = "93a02d342ce934f890fa39865cf7d2f3485d19a805b7c570ea33819106df1c21"
 dependencies = [
  "assert-json-diff",
+ "async-object-pool",
  "async-trait",
- "base64 0.13.0",
+ "base64",
  "basic-cookies",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils",
  "difference",
  "futures-util",
- "hyper",
+ "hyper 0.14.4",
  "isahc",
  "lazy_static",
  "levenshtein",
  "log",
- "puddle",
  "qstring",
  "regex",
  "serde",
  "serde_json",
  "serde_regex",
- "tokio",
+ "tokio 1.2.0",
 ]
 
 [[package]]
@@ -987,19 +1045,42 @@ version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project",
  "socket2",
- "tokio",
+ "tokio 0.2.25",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.4.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project",
+ "socket2",
+ "tokio 1.2.0",
  "tower-service",
  "tracing",
  "want",
@@ -1007,14 +1088,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes",
- "hyper",
+ "bytes 0.5.6",
+ "hyper 0.13.10",
  "native-tls",
- "tokio",
+ "tokio 0.2.25",
  "tokio-tls",
 ]
 
@@ -1031,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1042,11 +1123,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.3.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1068,20 +1150,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "isahc"
-version = "0.9.12"
+name = "ipnet"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003be15733203fb6e7a926e4a23517b0dbc45e4ab3ead5bbc24c7ad84faae681"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+
+[[package]]
+name = "isahc"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3d0a62435883f745c825ec06a03a38d24bf5fa65c43e2c083b6a60ce0058ae"
 dependencies = [
- "bytes",
- "crossbeam-channel 0.5.0",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils",
  "curl",
  "curl-sys",
  "encoding_rs",
- "futures-channel",
- "futures-io",
- "futures-util",
+ "flume",
+ "futures-lite",
  "http",
  "log",
  "mime",
@@ -1090,6 +1175,8 @@ dependencies = [
  "sluice",
  "tracing",
  "tracing-futures",
+ "url 2.2.1",
+ "waker-fn",
 ]
 
 [[package]]
@@ -1109,15 +1196,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1147,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "kiln_lib"
 version = "0.4.3"
-source = "git+https://github.com/simplybusiness/Kiln?branch=main#8d0494ccc4fa205e941b18c461d01f7ec542c827"
+source = "git+https://github.com/simplybusiness/Kiln?branch=main#c0d85ee570ff7a784755704f87c4436b274b856f"
 dependencies = [
  "addr",
  "avro-rs",
@@ -1162,7 +1249,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "url 2.1.1",
+ "url 2.2.1",
  "uuid",
 ]
 
@@ -1195,7 +1282,7 @@ dependencies = [
  "string_cache",
  "term",
  "tiny-keccak",
- "unicode-xid 0.2.0",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -1260,6 +1347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,16 +1383,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "mime"
@@ -1316,11 +1406,12 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.6"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
+checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
- "adler32",
+ "adler",
+ "autocfg",
 ]
 
 [[package]]
@@ -1343,26 +1434,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio-named-pipes"
-version = "0.1.6"
+name = "mio"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.6",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
- "mio",
- "miow 0.3.3",
+ "mio 0.6.23",
+ "miow 0.3.6",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "mio-uds"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.23",
 ]
 
 [[package]]
@@ -1379,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -1389,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1403,6 +1507,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nb-connect"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
+dependencies = [
+ "libc",
+ "socket2",
 ]
 
 [[package]]
@@ -1423,10 +1537,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
-name = "num-integer"
-version = "0.1.42"
+name = "ntapi"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1434,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -1469,9 +1592,15 @@ checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
+
+[[package]]
+name = "object"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
@@ -1481,12 +1610,12 @@ checksum = "4ad167a2f54e832b82dbe003a046280dceffe5227b5f79e08e363a29638cfddd"
 
 [[package]]
 name = "openssl"
-version = "0.10.29"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1501,18 +1630,18 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.9.0+1.1.1g"
+version = "111.14.0+1.1.1j"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2dbe10ddd1eb335aba3780eb2eaa13e1b7b441d2562fd962398740927f39ec4"
+checksum = "055b569b5bd7e5462a1700f595c7c7d487691d73b5ce064176af7f9f0cbb80a9"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.55"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg",
  "cc",
@@ -1581,15 +1710,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.4"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
@@ -1605,28 +1734,28 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polling"
-version = "1.1.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0720e0b9ea9d52451cf29d3413ba8a9303f8815d9d9653ef70e03ff73e65566"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "log",
- "wepoll-sys-stjepang",
+ "wepoll-sys",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "precomputed-hash"
@@ -1636,9 +1765,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
  "toml",
 ]
@@ -1651,7 +1780,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
  "version_check",
 ]
@@ -1663,7 +1792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "version_check",
 ]
 
@@ -1675,9 +1804,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1694,7 +1823,7 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid 0.2.0",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -1734,15 +1863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "puddle"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf84452e80b28e2b05e53964d6f5a44a57978ce19b4920be49e1a61079a24d7"
-dependencies = [
- "async-std",
-]
-
-[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2 1.0.24",
 ]
@@ -1784,25 +1904,24 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
  "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1822,20 +1941,20 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1878,9 +1997,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
@@ -1888,8 +2016,8 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
- "redox_syscall",
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
@@ -1913,9 +2041,9 @@ checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -1937,7 +2065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -1967,26 +2095,27 @@ dependencies = [
  "slog",
  "slog-async",
  "slog_derive",
- "tokio",
- "url 2.1.1",
+ "tokio 0.2.25",
+ "url 2.2.1",
  "uuid",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.10.4"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
- "base64 0.11.0",
- "bytes",
+ "base64",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.3.1",
+ "hyper 0.13.10",
  "hyper-tls",
+ "ipnet",
  "js-sys",
  "lazy_static",
  "log",
@@ -1994,13 +2123,12 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.1.4",
+ "pin-project-lite 0.2.4",
  "serde",
  "serde_urlencoded",
- "time",
- "tokio",
+ "tokio 0.2.25",
  "tokio-tls",
- "url 2.1.1",
+ "url 2.2.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2009,13 +2137,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.12"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
- "lazy_static",
  "libc",
+ "once_cell",
  "spin",
  "untrusted",
  "web-sys",
@@ -2034,17 +2162,17 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "rustc_version"
@@ -2063,15 +2191,15 @@ checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
 
 [[package]]
 name = "ryu"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schannel"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi 0.3.9",
@@ -2084,10 +2212,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
-name = "security-framework"
-version = "0.4.3"
+name = "scopeguard"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f331b9025654145cd425b9ded0caf8f5ae0df80d418b326e2dc1c3dc5eb0620"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2098,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2143,7 +2277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2170,14 +2304,14 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "dtoa",
+ "form_urlencoded",
  "itoa",
+ "ryu",
  "serde",
- "url 2.1.1",
 ]
 
 [[package]]
@@ -2213,20 +2347,20 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "slog"
-version = "2.5.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 dependencies = [
  "erased-serde",
 ]
 
 [[package]]
 name = "slog-async"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b3336ce47ce2f96673499fc07eb85e3472727b9a7a2959964b002c2ce8fbbb"
+checksum = "c60813879f820c85dbc4eabf3269befe374591289019775898d56a81a804fbdc"
 dependencies = [
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "slog",
  "take_mut",
  "thread_local",
@@ -2239,7 +2373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2255,20 +2389,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
-
-[[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -2279,10 +2406,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
+name = "spinning_top"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+checksum = "7e529d73e80d64b5f2631f9035113347c578a1c9c7774b83a2b880788459ab36"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "string_cache"
@@ -2314,20 +2450,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
- "unicode-xid 0.2.0",
+ "quote 1.0.9",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
- "unicode-xid 0.2.0",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -2338,14 +2474,14 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand 0.8.3",
+ "redox_syscall 0.2.5",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2363,31 +2499,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -2410,27 +2546,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
  "libc",
  "memchr",
- "mio",
+ "mio 0.6.23",
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
- "pin-project-lite 0.1.4",
+ "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
- "tokio-macros",
+ "tokio-macros 0.2.6",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+dependencies = [
+ "autocfg",
+ "libc",
+ "mio 0.7.9",
+ "num_cpus",
+ "pin-project-lite 0.2.4",
+ "tokio-macros 1.1.0",
 ]
 
 [[package]]
@@ -2440,18 +2605,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
 [[package]]
 name = "tokio-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -2460,28 +2636,28 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.4",
- "tokio",
+ "pin-project-lite 0.1.11",
+ "tokio 0.2.25",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tower-service"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
@@ -2503,7 +2679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2528,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
@@ -2558,11 +2734,11 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.12"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
- "smallvec",
+ "tinyvec",
 ]
 
 [[package]]
@@ -2573,15 +2749,15 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "untrusted"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -2596,22 +2772,23 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
- "idna 0.2.0",
+ "form_urlencoded",
+ "idna 0.2.2",
  "matches",
  "percent-encoding 2.1.0",
 ]
 
 [[package]]
 name = "uuid"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "rand 0.7.3",
+ "getrandom 0.2.2",
  "serde",
 ]
 
@@ -2626,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec-arena"
@@ -2638,9 +2815,9 @@ checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "waker-fn"
@@ -2665,12 +2842,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.60"
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -2678,26 +2861,26 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.10"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
+checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -2705,22 +2888,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.9",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.3",
+ "quote 1.0.9",
  "syn 1.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -2728,25 +2911,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
 
 [[package]]
 name = "web-sys"
-version = "0.3.37"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "wepoll-sys-stjepang"
-version = "1.0.8"
+name = "wepoll-sys"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdfbb03f290ca0b27922e8d48a0997b4ceea12df33269b9f75e713311eb178d"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
 dependencies = [
  "cc",
 ]
@@ -2787,9 +2970,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winreg"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/report-parser/Cargo.lock
+++ b/report-parser/Cargo.lock
@@ -30,10 +30,182 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "0.4.6"
+name = "arrayref"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "ascii-canvas"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8eb72df928aafb99fe5d37b383f2fe25bd2a765e3e5f7c365916b6f2463a29"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259cbe96513d2f1073027a259fc2ca917feb3026a5a8d984e3628e490255cc0"
+dependencies = [
+ "extend",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba0529565cae1f732d469f06fedff0f75d0e27eb22129ddf5707cef8bd7a2cfe"
+dependencies = [
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "vec-arena",
+ "waker-fn",
+ "wepoll-sys-stjepang",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-process"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef37b86e2fa961bae5a4d212708ea0154f904ce31d1a4a7f47e1bbc33a0c040b"
+dependencies = [
+ "async-io",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "futures-lite",
+ "once_cell",
+ "signal-hook",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-std"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f84f1280a2b436a2c77c2582602732b6c2f4321d5494d6e799e6c367859a8"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-mutex",
+ "async-process",
+ "blocking",
+ "crossbeam-utils 0.8.2",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite 0.2.4",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "autocfg"
@@ -62,7 +234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
 dependencies = [
  "backtrace-sys",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rustc-demangle",
 ]
@@ -84,10 +256,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "basic-cookies"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb53b6b315f924c7f113b162e53b3901c05fc9966baf84d201dfcc7432a4bb38"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
 
 [[package]]
 name = "bumpalo"
@@ -96,10 +325,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 
 [[package]]
+name = "byteorder"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+
+[[package]]
 name = "bytes"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
@@ -112,6 +353,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -144,6 +391,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,7 +427,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -174,8 +436,18 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.2",
 ]
 
 [[package]]
@@ -185,8 +457,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "lazy_static",
+ "loom",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "ctor"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
+dependencies = [
+ "quote 1.0.3",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "curl"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e268162af1a5fe89917ae25ba3b0a77c8da752bdc58e7dbb4f15b91fbd33756e"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.40+curl-7.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffafc1c35958318bd7fdd0582995ce4c72f4f461a8e70499ccee83a619fd562"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -201,10 +532,22 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
@@ -216,10 +559,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "ena"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -227,7 +596,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -250,6 +619,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
+name = "extend"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "syn 1.0.60",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,11 +652,26 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
  "synstructure",
 ]
+
+[[package]]
+name = "fastrand"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
@@ -277,7 +679,7 @@ version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -343,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.4"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -353,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.4"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-executor"
@@ -370,39 +772,57 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.4"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+
+[[package]]
+name = "futures-lite"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite 0.2.4",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.4"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.4"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.4"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.4"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -411,10 +831,24 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -432,9 +866,22 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -502,10 +949,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
-name = "hyper"
-version = "0.13.5"
+name = "httpdate"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "httpmock"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e098238acaa95e0bb3fd357317817fde35efb9cdedf74b18b24698499eea9d"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.13.0",
+ "basic-cookies",
+ "crossbeam-utils 0.8.2",
+ "difference",
+ "futures-util",
+ "hyper",
+ "isahc",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "puddle",
+ "qstring",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "tokio",
+]
+
+[[package]]
+name = "hyper"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -515,13 +995,13 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
- "log",
- "net2",
  "pin-project",
- "time",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
  "want",
 ]
 
@@ -570,6 +1050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,10 +1068,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "isahc"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003be15733203fb6e7a926e4a23517b0dbc45e4ab3ead5bbc24c7ad84faae681"
+dependencies = [
+ "bytes",
+ "crossbeam-channel 0.5.0",
+ "crossbeam-utils 0.8.2",
+ "curl",
+ "curl-sys",
+ "encoding_rs",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "http",
+ "log",
+ "mime",
+ "once_cell",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "iter-read"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d03e6379deaba8f70d594164614dbae5d5354e861d7a9f9864a7492f6a29b303"
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -644,16 +1167,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a71d75b267b3299da9ccff4dd80d73325b5d8adcd76fe97cf92725eb7c6f122"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ebbd90154472db6267a7d28ca08fea7788e5619fef10f2398155cb74c08f77a"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.69"
+name = "levenshtein"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
+name = "libc"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "libflate"
@@ -668,10 +1238,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.0.25"
+name = "libnghttp2-sys"
+version = "0.1.6+1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+checksum = "0af55541a8827e138d59ec9e5877fb6095ece63fb6f4da45e7491b4fbd262855"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
  "libc",
@@ -681,11 +1261,23 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+ "value-bag",
+]
+
+[[package]]
+name = "loom"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
 ]
 
 [[package]]
@@ -733,18 +1325,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.21"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -759,7 +1351,7 @@ dependencies = [
  "log",
  "mio",
  "miow 0.3.3",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -775,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -792,7 +1384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 dependencies = [
  "socket2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -815,14 +1407,20 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.33"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "num-integer"
@@ -870,10 +1468,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad167a2f54e832b82dbe003a046280dceffe5227b5f79e08e363a29638cfddd"
 
 [[package]]
 name = "openssl"
@@ -882,7 +1486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -919,6 +1523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,23 +1541,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pin-project"
-version = "0.4.9"
+name = "petgraph"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9b4df73455c861d7cbf8be42f01d3b373ed7f02e378d55fa84eafc6f638b1"
+
+[[package]]
+name = "pin-project"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.9"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
+checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -955,6 +1590,12 @@ name = "pin-project-lite"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -969,10 +1610,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
+name = "polling"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0720e0b9ea9d52451cf29d3413ba8a9303f8815d9d9653ef70e03ff73e65566"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log",
+ "wepoll-sys-stjepang",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-crate"
@@ -984,10 +1644,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.15"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "syn 1.0.60",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -1006,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -1050,6 +1734,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "puddle"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cf84452e80b28e2b05e53964d6f5a44a57978ce19b4920be49e1a61079a24d7"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "qstring"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
+dependencies = [
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,7 +1766,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
 ]
 
 [[package]]
@@ -1077,7 +1779,7 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1181,10 +1883,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
-name = "regex"
-version = "1.3.7"
+name = "redox_users"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
+name = "regex"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1194,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.17"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -1204,7 +1917,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1223,9 +1936,9 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1241,6 +1954,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "hex",
+ "httpmock",
  "iter-read",
  "kiln_lib",
  "lazy_static",
@@ -1264,7 +1978,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1280,7 +1994,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite",
+ "pin-project-lite 0.1.4",
  "serde",
  "serde_urlencoded",
  "time",
@@ -1305,7 +2019,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1313,6 +2027,18 @@ name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64 0.13.0",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils 0.8.2",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -1330,6 +2056,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
 name = "ryu"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,8 +2074,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
 dependencies = [
  "lazy_static",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "security-framework"
@@ -1391,32 +2129,42 @@ checksum = "1ee22067b7ccd072eeb64454b9c6e1b33b61cd0d49e895fd48676a184580e0c3"
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
  "serde",
 ]
 
@@ -1433,14 +2181,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.2.0"
+name = "signal-hook"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+checksum = "8a7f3f92a1da3d6b1d32245d0cbcbbab0cfc45996d8df619c42bccfa6d2bbb5f"
 dependencies = [
- "arc-swap",
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 
 [[package]]
 name = "slab"
@@ -1463,7 +2226,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b3336ce47ce2f96673499fc07eb85e3472727b9a7a2959964b002c2ce8fbbb"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-channel 0.4.4",
  "slog",
  "take_mut",
  "thread_local",
@@ -1475,9 +2238,20 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "sluice"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fa0333a60ff2e3474a6775cc611840c2a55610c831dd366503474c02f1a28f5"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
 ]
 
 [[package]]
@@ -1492,10 +2266,10 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1511,6 +2285,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
+name = "string_cache"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb1139b5353f96e429e1a5e19fbaf663bddedaa06d1dbd49f82e352601209a"
+dependencies = [
+ "lazy_static",
+ "new_debug_unreachable",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,11 +2309,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.18"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
@@ -1538,9 +2324,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
  "unicode-xid 0.2.0",
 ]
 
@@ -1556,12 +2342,23 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.8",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "term"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+dependencies = [
+ "byteorder",
+ "dirs",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1579,9 +2376,9 @@ version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1600,14 +2397,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
 name = "tokio"
-version = "0.2.18"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ef16d072d2b6dc8b4a56c70f5c5ced1a37752116f8e7c1e80c659aa7cb6713"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
  "bytes",
  "fnv",
@@ -1620,22 +2426,22 @@ dependencies = [
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.4",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1658,7 +2464,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.4",
  "tokio",
 ]
 
@@ -1676,6 +2482,49 @@ name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "tracing"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f77d3842f76ca899ff2dbcf231c5c65813dea431301d6eb686279c15c4464f12"
+dependencies = [
+ "cfg-if 1.0.0",
+ "log",
+ "pin-project-lite 0.2.4",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
 
 [[package]]
 name = "try-lock"
@@ -1767,16 +2616,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.0.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
+dependencies = [
+ "ctor",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+
+[[package]]
 name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"
@@ -1800,7 +2670,7 @@ version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -1815,9 +2685,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -1827,7 +2697,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1849,9 +2719,9 @@ version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.18",
+ "syn 1.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1873,6 +2743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wepoll-sys-stjepang"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fdfbb03f290ca0b27922e8d48a0997b4ceea12df33269b9f75e713311eb178d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,9 +2759,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -1912,7 +2791,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/report-parser/Cargo.lock
+++ b/report-parser/Cargo.lock
@@ -135,6 +135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "compressed_string"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3191fb9cd59eb0195c223d4f1d8894d2078957ee44f4940f059d11060a6d0e7"
+dependencies = [
+ "flate2",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,6 +1234,7 @@ version = "0.4.3"
 dependencies = [
  "avro-rs",
  "chrono",
+ "compressed_string",
  "data-encoding",
  "erased-serde",
  "failure",

--- a/report-parser/Cargo.toml
+++ b/report-parser/Cargo.toml
@@ -28,3 +28,4 @@ slog-async = { version = "2.5", features = [ "nested-values",] }
 slog_derive = "0.2"
 erased-serde = "0.3"
 compressed_string = "1"
+httpmock = "0.5"

--- a/report-parser/Cargo.toml
+++ b/report-parser/Cargo.toml
@@ -27,3 +27,4 @@ slog = { version = "2.5", features = [ "nested-values",] }
 slog-async = { version = "2.5", features = [ "nested-values",] }
 slog_derive = "0.2"
 erased-serde = "0.3"
+compressed_string = "1"

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -20,11 +20,7 @@ use kiln_lib::dependency_event::{
 };
 use kiln_lib::kafka::*;
 use kiln_lib::log::NestedJsonFmt;
-use kiln_lib::tool_report::{
-    ApplicationName, EndTime, Environment, EventID, EventVersion, GitBranch, GitCommitHash,
-    IssueHash, OutputFormat, StartTime, SuppressedIssue, ToolName, ToolOutput, ToolReport,
-    ToolVersion
-};
+use kiln_lib::tool_report::{EventID, EventVersion, IssueHash, SuppressedIssue, ToolReport};
 use kiln_lib::traits::Hashable;
 use rdkafka::consumer::{CommitMode, Consumer};
 use rdkafka::message::Message;
@@ -34,7 +30,7 @@ use reqwest::blocking::Client;
 use reqwest::header::ETAG;
 use ring::digest;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::Value;
 use std::boxed::Box;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -49,8 +45,6 @@ use slog::Drain;
 use slog::{FnValue, PushFnValue};
 use slog_derive::SerdeValue;
 use uuid::Uuid;
-
-use httpmock::MockServer;
 
 const SERVICE_NAME: &str = "report-parser";
 const PYTHON_SAFETY_VULN_URL: &str =
@@ -849,7 +843,14 @@ fn should_issue_be_suppressed(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use httpmock::MockServer;
+    use kiln_lib::tool_report::{
+        ApplicationName, EndTime, Environment, EventID, EventVersion, GitBranch, GitCommitHash,
+        IssueHash, OutputFormat, StartTime, SuppressedIssue, ToolName, ToolOutput, ToolReport,
+        ToolVersion,
+    };
     use kiln_lib::tool_report::{ExpiryDate, SuppressedBy, SuppressionReason};
+    use serde_json::json;
 
     #[test]
     fn issue_suppression_works_when_suppressed_issues_is_empty() {

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -48,7 +48,7 @@ use uuid::Uuid;
 
 const SERVICE_NAME: &str = "report-parser";
 const PYTHON_SAFETY_VULN_URL: &str =
-"https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json";
+    "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 Uuid::new_v4().to_hyphenated().to_string()
             }),
         ),
-        );
+    );
 
     let error_logger = root_logger.new(o!("event.type" => EventType(vec!("error".to_string()))));
 
@@ -121,7 +121,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let base_url = Url::parse(
         &env::var("NVD_BASE_URL")
-        .unwrap_or_else(|_| "https://nvd.nist.gov/feeds/json/cve/1.1/".to_string()),
+            .unwrap_or_else(|_| "https://nvd.nist.gov/feeds/json/cve/1.1/".to_string()),
     )?;
     let mut last_updated_time = None;
     let client_builder = Client::builder();
@@ -141,23 +141,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 );
                 err
             })
-        .and_then(|parsed_vulns| {
-            parsed_vulns
-                .into_iter()
-                .fold(&mut vulns, |acc, mut values| {
-                    for (k, v) in values.drain() {
-                        acc.insert(k, v);
-                    }
-                    acc
-                });
-            info!(root_logger, "Successfully got vulns for {}", year;
-                o!(
-                    "event.type" => EventType(vec!("info".to_string())),
-                )
-            );
-            Ok(())
-        })?;
-            }
+            .and_then(|parsed_vulns| {
+                parsed_vulns
+                    .into_iter()
+                    .fold(&mut vulns, |acc, mut values| {
+                        for (k, v) in values.drain() {
+                            acc.insert(k, v);
+                        }
+                        acc
+                    });
+                info!(root_logger, "Successfully got vulns for {}", year;
+                    o!(
+                        "event.type" => EventType(vec!("info".to_string())),
+                    )
+                );
+                Ok(())
+            })?;
+    }
 
     download_and_parse_vulns(
         "modified".to_string(),
@@ -165,14 +165,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &base_url,
         &client,
     )
-        .map_err(|err| {
-            error!(error_logger, "Error downloading modified vulns info";
-                o!(
-                    "error.message" => err.to_string(),
-                )
-            );
-            err
-        })
+    .map_err(|err| {
+        error!(error_logger, "Error downloading modified vulns info";
+            o!(
+                "error.message" => err.to_string(),
+            )
+        );
+        err
+    })
     .and_then(|modified_vulns| {
         modified_vulns
             .into_iter()
@@ -193,14 +193,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut etag = None;
     let mut safety_cve_map =
         download_and_parse_python_safety_vulns(&PYTHON_SAFETY_VULN_URL, &mut etag, &client)
-        .map_err(|err| {
-            error!(error_logger, "Error downloading Python Safety Vulns";
-                o!(
-                    "error.message" => err.to_string(),
-                )
-            );
-            err
-        })?;
+            .map_err(|err| {
+                error!(error_logger, "Error downloading Python Safety Vulns";
+                    o!(
+                        "error.message" => err.to_string(),
+                    )
+                );
+                err
+            })?;
 
     info!(root_logger, "Successfully got Python dependency vulns from Safety tool database";
         o!(
@@ -214,18 +214,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
     loop {
         if last_updated_time
             .unwrap()
-                .lt(&(Utc::now() - Duration::days(1)))
+            .lt(&(Utc::now() - Duration::days(1)))
         {
             let new_safety_cve_map =
                 download_and_parse_python_safety_vulns(&PYTHON_SAFETY_VULN_URL, &mut etag, &client)
-                .map_err(|err| {
-                    error!(error_logger, "Error downloading Python Safety Vulns";
-                        o!(
-                            "error.message" => err.to_string(),
-                        )
-                    );
-                    err
-                })?;
+                    .map_err(|err| {
+                        error!(error_logger, "Error downloading Python Safety Vulns";
+                            o!(
+                                "error.message" => err.to_string(),
+                            )
+                        );
+                        err
+                    })?;
             if new_safety_cve_map.is_some() {
                 safety_cve_map = new_safety_cve_map;
             }
@@ -233,7 +233,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         if last_updated_time
             .unwrap()
-                .lt(&(Utc::now() - Duration::hours(2)))
+            .lt(&(Utc::now() - Duration::hours(2)))
         {
             download_and_parse_vulns(
                 "modified".to_string(),
@@ -241,14 +241,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 &base_url,
                 &client,
             )
-                .map_err(|err| {
-                    error!(error_logger, "Error updating vuln info";
-                        o!(
-                            "error.message" => err.to_string(),
-                        )
-                    );
-                    err
-                })
+            .map_err(|err| {
+                error!(error_logger, "Error updating vuln info";
+                    o!(
+                        "error.message" => err.to_string(),
+                    )
+                );
+                err
+            })
             .and_then(|modified_vulns| {
                 if let Some(mut modified_vulns) = modified_vulns {
                     for (k, v) in modified_vulns.drain() {
@@ -287,14 +287,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     let app_name = report.application_name.to_string();
                     let records =
                         parse_tool_report(&report, &vulns, safety_cve_map.as_ref().unwrap())
-                        .map_err(|err| {
-                            error!(error_logger, "Error parsing tool output in ToolReport";
-                                o!(
-                                    "error.message" => err.to_string(),
-                                )
-                            );
-                            err
-                        })?;
+                            .map_err(|err| {
+                                error!(error_logger, "Error parsing tool output in ToolReport";
+                                    o!(
+                                        "error.message" => err.to_string(),
+                                    )
+                                );
+                                err
+                            })?;
                     for record in records.into_iter() {
                         let kafka_payload = FutureRecord::to("DependencyEvents")
                             .payload(&record)
@@ -353,13 +353,13 @@ fn download_and_parse_vulns(
         .map_err(|err| {
             Box::new(err_msg(format!("Error downloading {}: {}", meta_filename, err)).compat())
         })
-    .and_then(|resp| {
-        resp.text().map_err(|err| {
-            Box::new(
-                err_msg(format!("Error reading body of {}: {}", meta_filename, err)).compat(),
-            )
-        })
-    })?;
+        .and_then(|resp| {
+            resp.text().map_err(|err| {
+                Box::new(
+                    err_msg(format!("Error reading body of {}: {}", meta_filename, err)).compat(),
+                )
+            })
+        })?;
 
     let last_mod_timestamp = META_LAST_MOD_RE
         .captures(&meta_resp_text)
@@ -367,21 +367,21 @@ fn download_and_parse_vulns(
         .ok_or_else(|| {
             Box::new(
                 err_msg(format!(
-                        "Error reading lastModifiedDate from {}",
-                        meta_filename
+                    "Error reading lastModifiedDate from {}",
+                    meta_filename
                 ))
                 .compat(),
             )
         })
-    .map(|capture| capture.as_str())?;
+        .map(|capture| capture.as_str())?;
 
-let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
-    .captures(&meta_resp_text)
-    .and_then(|captures| captures.get(1))
-    .ok_or_else(|| {
-        Box::new(err_msg(format!("Error reading size from {}", meta_filename)).compat())
-    })
-.map(|capture| capture.as_str())?;
+    let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
+        .captures(&meta_resp_text)
+        .and_then(|captures| captures.get(1))
+        .ok_or_else(|| {
+            Box::new(err_msg(format!("Error reading size from {}", meta_filename)).compat())
+        })
+        .map(|capture| capture.as_str())?;
 
     let compressed_size = META_COMPRESSED_GZ_SIZE_RE
         .captures(&meta_resp_text)
@@ -389,21 +389,21 @@ let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
         .ok_or_else(|| {
             Box::new(
                 err_msg(format!(
-                        "Error reading compressed size from {}",
-                        meta_filename
+                    "Error reading compressed size from {}",
+                    meta_filename
                 ))
                 .compat(),
             )
         })
-    .map(|capture| capture.as_str())?;
+        .map(|capture| capture.as_str())?;
 
-let hash = META_SHA256_RE
-    .captures(&meta_resp_text)
-    .and_then(|captures| captures.get(1))
-    .ok_or_else(|| {
-        Box::new(err_msg(format!("Error reading sha256 hash from {}", meta_filename)).compat())
-    })
-.map(|capture| capture.as_str())?;
+    let hash = META_SHA256_RE
+        .captures(&meta_resp_text)
+        .and_then(|captures| captures.get(1))
+        .ok_or_else(|| {
+            Box::new(err_msg(format!("Error reading sha256 hash from {}", meta_filename)).compat())
+        })
+        .map(|capture| capture.as_str())?;
 
     if last_updated_time.is_none()
         || last_updated_time
@@ -434,11 +434,11 @@ let hash = META_SHA256_RE
 
         if hash != computed_hash {
             return Err(Box::new(
-                    err_msg(format!(
-                            "Hash mismatch for {}, expected {}, got {}",
-                            data_filename, hash, computed_hash
-                    ))
-                    .compat(),
+                err_msg(format!(
+                    "Hash mismatch for {}, expected {}, got {}",
+                    data_filename, hash, computed_hash
+                ))
+                .compat(),
             ));
         }
 
@@ -493,9 +493,9 @@ let hash = META_SHA256_RE
 
                 (
                     vuln_info["cve"]["CVE_data_meta"]["ID"]
-                    .as_str()
-                    .unwrap()
-                    .to_string(),
+                        .as_str()
+                        .unwrap()
+                        .to_string(),
                     VulnData {
                         advisory_str: compr_adv_text,
                         advisory_url: adv_url_str.to_string(),
@@ -503,9 +503,9 @@ let hash = META_SHA256_RE
                     },
                 )
             })
-        .collect::<HashMap<_, _>>();
+            .collect::<HashMap<_, _>>();
 
-    return Ok(Some(cve_items));
+        return Ok(Some(cve_items));
     }
 
     Ok(None)
@@ -521,13 +521,13 @@ fn parse_tool_report(
             parse_bundler_audit_plaintext(&report, &vulns)
         } else {
             Err(Box::new(
-                    err_msg(format!(
-                            "Unknown output format for Bundler-audit in ToolReport: {:?}",
-                            report
-                    ))
-                    .compat(),
+                err_msg(format!(
+                    "Unknown output format for Bundler-audit in ToolReport: {:?}",
+                    report
+                ))
+                .compat(),
             )
-                .into())
+            .into())
         }
     } else if report.tool_name == "safety" {
         if report.output_format == "JSON" {
@@ -543,13 +543,13 @@ fn parse_tool_report(
                 .into())
         } else {
             Err(Box::new(
-                    err_msg(format!(
-                            "Unknown output format for safety in ToolReport: {:?}",
-                            report
-                    ))
-                    .compat(),
+                err_msg(format!(
+                    "Unknown output format for safety in ToolReport: {:?}",
+                    report
+                ))
+                .compat(),
             )
-                .into())
+            .into())
         }
     } else {
         Err(Box::new(err_msg(format!("Unknown tool in ToolReport: {:?}", report)).compat()).into())
@@ -591,11 +591,11 @@ fn parse_bundler_audit_plaintext(
             .collect::<HashMap<_, _>>();
         let advisory_id = AdvisoryId::try_from(
             fields
-            .get("Advisory")
-            .cloned()
-            .or_else(|| Some("".to_string()))
-            .unwrap()
-            .to_owned(),
+                .get("Advisory")
+                .cloned()
+                .or_else(|| Some("".to_string()))
+                .unwrap()
+                .to_owned(),
         )?;
 
         let cvss = vulns
@@ -612,36 +612,36 @@ fn parse_bundler_audit_plaintext(
             timestamp: Timestamp::try_from(report.end_time.to_string())?,
             affected_package: AffectedPackage::try_from(
                 fields
-                .get("Name")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+                    .get("Name")
+                    .cloned()
+                    .or_else(|| Some("".to_string()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             installed_version: InstalledVersion::try_from(
                 fields
-                .get("Version")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+                    .get("Version")
+                    .cloned()
+                    .or_else(|| Some("".to_string()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             advisory_url: AdvisoryUrl::try_from(
                 fields
-                .get("URL")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+                    .get("URL")
+                    .cloned()
+                    .or_else(|| Some("".to_string()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             advisory_id,
             advisory_description: AdvisoryDescription::try_from(
                 fields
-                .get("Title")
-                .cloned()
-                .or_else(|| Some("".to_owned()))
-                .unwrap()
-                .to_owned(),
+                    .get("Title")
+                    .cloned()
+                    .or_else(|| Some("".to_owned()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             cvss: cvss.clone(),
             suppressed: false,
@@ -714,14 +714,14 @@ fn download_and_parse_python_safety_vulns(
         }
     } else {
         return Err(Box::new(
-                err_msg(format!(
-                        "Unable to grab head from python safety database: ({})",
-                        head_resp.status()
-                ))
-                .compat(),
+            err_msg(format!(
+                "Unable to grab head from python safety database: ({})",
+                head_resp.status()
+            ))
+            .compat(),
         )
-            .into());
-        }
+        .into());
+    }
 
     let safety_db_resp_text = reqwest::blocking::get(safety_json_db_url)?.text()?;
     let python_safety_vuln_info_json: HashMap<String, SafetyJsonData> =
@@ -734,17 +734,17 @@ fn download_and_parse_python_safety_vulns(
             SafetyJsonData::Vuln(_s) => true,
             _ => false,
         })
-    .map(|s| match s {
-        SafetyJsonData::Vuln(s) => s.iter(),
-        _ => unreachable!(),
-    })
-    .flatten()
+        .map(|s| match s {
+            SafetyJsonData::Vuln(s) => s.iter(),
+            _ => unreachable!(),
+        })
+        .flatten()
         .map(|p| match &p.cve {
             Value::String(s) => (p.id.to_owned(), Some(s.to_owned())),
             _ => (p.id.to_owned(), None),
         })
-    .collect::<HashMap<_, _>>();
-Ok(Some(cve_items))
+        .collect::<HashMap<_, _>>();
+    Ok(Some(cve_items))
 }
 
 fn parse_safety_json(
@@ -871,9 +871,9 @@ fn should_issue_be_suppressed(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use httpmock::MockServer;
     use httpmock::Method::GET;
     use httpmock::Method::HEAD;
+    use httpmock::MockServer;
     use kiln_lib::tool_report::{
         ApplicationName, EndTime, Environment, EventID, EventVersion, GitBranch, GitCommitHash,
         IssueHash, OutputFormat, StartTime, SuppressedIssue, ToolName, ToolOutput, ToolReport,
@@ -887,7 +887,7 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
@@ -901,15 +901,15 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![SuppressedIssue {
             issue_hash: IssueHash::try_from(
-                            "a441b688fb60942c701fbcee0f30c66c0f7b22da7f0b4c51488488d2a2b64197".to_owned(),
-                        )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                "a441b688fb60942c701fbcee0f30c66c0f7b22da7f0b4c51488488d2a2b64197".to_owned(),
+            )
+            .unwrap(),
+            expiry_date: ExpiryDate::from(None),
+            suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+            suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
         }];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
@@ -923,26 +923,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 20).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 20).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "46a9d5bde718bf366178313019f04a753bad00685d38e3ec81c8628f35dfcb1b".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "46a9d5bde718bf366178313019f04a753bad00685d38e3ec81c8628f35dfcb1b".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -958,26 +958,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(0, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(0, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "9cf8847d2992e7219e659cdde1969e0d567ebab39a7aba13b36f9916fa26f6ca".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "9cf8847d2992e7219e659cdde1969e0d567ebab39a7aba13b36f9916fa26f6ca".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -993,26 +993,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 18).and_hms(10, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 18).and_hms(10, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "b100dabbadeedabbad1eadabbadeedabbad1edabbadeedabbad1eadabbadeeda".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "b100dabbadeedabbad1eadabbadeedabbad1edabbadeedabbad1eadabbadeeda".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -1028,26 +1028,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "a41f58ced5996b018dfbd697c1b16675f0cf864a3475d237cdd3f4d8c7160fdb".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "a41f58ced5996b018dfbd697c1b16675f0cf864a3475d237cdd3f4d8c7160fdb".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -1063,29 +1063,29 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 19).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 19).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
-            ];
+        ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
             true,
@@ -1099,29 +1099,29 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
-            ];
+        ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
             true,
@@ -1140,7 +1140,7 @@ mod tests {
         let client = Client::new();
         assert!(
             download_and_parse_python_safety_vulns(&server.url("/data"), &mut etag, &client)
-            .is_err(),
+                .is_err(),
             "HTTP error status not handled correctly"
         );
         mock.assert_hits(1);
@@ -1481,51 +1481,51 @@ mod tests {
         null
     ]]"#;
 
-    let advisory_text_1 = "Some advsiory text CVE-2020-13757";
-    let compr_adv_text_1 = ComprString::new(advisory_text_1);
-    let advisory_url_1 = "http://someurl-cve-2020-13757.co.uk/";
+        let advisory_text_1 = "Some advsiory text CVE-2020-13757";
+        let compr_adv_text_1 = ComprString::new(advisory_text_1);
+        let advisory_url_1 = "http://someurl-cve-2020-13757.co.uk/";
 
-    let advisory_text_2 = "Some advsiory text CVE-2020-14564";
-    let compr_adv_text_2 = ComprString::new(advisory_text_2);
-    let advisory_url_2 = "http://someurl-cve-2020-14564.co.uk/";
+        let advisory_text_2 = "Some advsiory text CVE-2020-14564";
+        let compr_adv_text_2 = ComprString::new(advisory_text_2);
+        let advisory_url_2 = "http://someurl-cve-2020-14564.co.uk/";
 
-    let safety_cve_map: HashMap<String, Option<String>> = [(
-        "pyup.io-38414".to_string(),
-        Some("CVE-2020-13757 , CVE-2020-14564".to_string()),
-    )]
+        let safety_cve_map: HashMap<String, Option<String>> = [(
+            "pyup.io-38414".to_string(),
+            Some("CVE-2020-13757 , CVE-2020-14564".to_string()),
+        )]
         .iter()
         .cloned()
         .collect();
 
-    let vulnshash: HashMap<String, VulnData> = [
-        (
-            "CVE-2020-13757".to_string(),
-            VulnData {
-                advisory_str: compr_adv_text_1,
-                advisory_url: advisory_url_1.to_string(),
-                cvss: Cvss::builder()
-                    .with_version(CvssVersion::V2)
-                    .with_score(Some(7.5))
-                    .build()
-                    .unwrap(),
-            },
-        ),
-        (
-            "CVE-2020-14564".to_string(),
-            VulnData {
-                advisory_str: compr_adv_text_2,
-                advisory_url: advisory_url_2.to_string(),
-                cvss: Cvss::builder()
-                    .with_version(CvssVersion::V2)
-                    .with_score(Some(7.5))
-                    .build()
-                    .unwrap(),
-            },
-        ),
+        let vulnshash: HashMap<String, VulnData> = [
+            (
+                "CVE-2020-13757".to_string(),
+                VulnData {
+                    advisory_str: compr_adv_text_1,
+                    advisory_url: advisory_url_1.to_string(),
+                    cvss: Cvss::builder()
+                        .with_version(CvssVersion::V2)
+                        .with_score(Some(7.5))
+                        .build()
+                        .unwrap(),
+                },
+            ),
+            (
+                "CVE-2020-14564".to_string(),
+                VulnData {
+                    advisory_str: compr_adv_text_2,
+                    advisory_url: advisory_url_2.to_string(),
+                    cvss: Cvss::builder()
+                        .with_version(CvssVersion::V2)
+                        .with_score(Some(7.5))
+                        .build()
+                        .unwrap(),
+                },
+            ),
         ]
-            .iter()
-            .cloned()
-            .collect();
+        .iter()
+        .cloned()
+        .collect();
         let test_report = ToolReport {
             event_version: EventVersion::try_from("1".to_owned()).unwrap(),
             event_id: EventID::try_from("95130bee-95ae-4dac-aecf-5650ff646ea1".to_owned()).unwrap(),
@@ -1534,19 +1534,19 @@ mod tests {
             git_commit_hash: GitCommitHash::try_from(
                 "e99f715d0fe787cd43de967b8a79b56960fed3e5".to_owned(),
             )
-                .unwrap(),
-                tool_name: ToolName::try_from("safety".to_owned()).unwrap(),
-                tool_output: ToolOutput::try_from(python_safety_vulns.to_owned()).unwrap(),
-                output_format: OutputFormat::JSON,
-                start_time: StartTime::from(DateTime::<Utc>::from(
-                        DateTime::parse_from_rfc3339("2019-09-13T19:35:38+00:00").unwrap(),
-                )),
-                end_time: EndTime::from(DateTime::<Utc>::from(
-                        DateTime::parse_from_rfc3339("2019-09-13T19:37:14+00:00").unwrap(),
-                )),
-                environment: Environment::Local,
-                tool_version: ToolVersion::try_from(Some("1.0".to_owned())).unwrap(),
-                suppressed_issues: vec![],
+            .unwrap(),
+            tool_name: ToolName::try_from("safety".to_owned()).unwrap(),
+            tool_output: ToolOutput::try_from(python_safety_vulns.to_owned()).unwrap(),
+            output_format: OutputFormat::JSON,
+            start_time: StartTime::from(DateTime::<Utc>::from(
+                DateTime::parse_from_rfc3339("2019-09-13T19:35:38+00:00").unwrap(),
+            )),
+            end_time: EndTime::from(DateTime::<Utc>::from(
+                DateTime::parse_from_rfc3339("2019-09-13T19:37:14+00:00").unwrap(),
+            )),
+            environment: Environment::Local,
+            tool_version: ToolVersion::try_from(Some("1.0".to_owned())).unwrap(),
+            suppressed_issues: vec![],
         };
         let events_res = parse_safety_json(&test_report, &vulnshash, &safety_cve_map);
         assert!(events_res.is_ok());

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -48,7 +48,7 @@ use uuid::Uuid;
 
 const SERVICE_NAME: &str = "report-parser";
 const PYTHON_SAFETY_VULN_URL: &str =
-    "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json";
+"https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 Uuid::new_v4().to_hyphenated().to_string()
             }),
         ),
-    );
+        );
 
     let error_logger = root_logger.new(o!("event.type" => EventType(vec!("error".to_string()))));
 
@@ -121,7 +121,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let base_url = Url::parse(
         &env::var("NVD_BASE_URL")
-            .unwrap_or_else(|_| "https://nvd.nist.gov/feeds/json/cve/1.1/".to_string()),
+        .unwrap_or_else(|_| "https://nvd.nist.gov/feeds/json/cve/1.1/".to_string()),
     )?;
     let mut last_updated_time = None;
     let client_builder = Client::builder();
@@ -141,23 +141,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 );
                 err
             })
-            .and_then(|parsed_vulns| {
-                parsed_vulns
-                    .into_iter()
-                    .fold(&mut vulns, |acc, mut values| {
-                        for (k, v) in values.drain() {
-                            acc.insert(k, v);
-                        }
-                        acc
-                    });
-                info!(root_logger, "Successfully got vulns for {}", year;
-                    o!(
-                        "event.type" => EventType(vec!("info".to_string())),
-                    )
-                );
-                Ok(())
-            })?;
-    }
+        .and_then(|parsed_vulns| {
+            parsed_vulns
+                .into_iter()
+                .fold(&mut vulns, |acc, mut values| {
+                    for (k, v) in values.drain() {
+                        acc.insert(k, v);
+                    }
+                    acc
+                });
+            info!(root_logger, "Successfully got vulns for {}", year;
+                o!(
+                    "event.type" => EventType(vec!("info".to_string())),
+                )
+            );
+            Ok(())
+        })?;
+            }
 
     download_and_parse_vulns(
         "modified".to_string(),
@@ -165,14 +165,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &base_url,
         &client,
     )
-    .map_err(|err| {
-        error!(error_logger, "Error downloading modified vulns info";
-            o!(
-                "error.message" => err.to_string(),
-            )
-        );
-        err
-    })
+        .map_err(|err| {
+            error!(error_logger, "Error downloading modified vulns info";
+                o!(
+                    "error.message" => err.to_string(),
+                )
+            );
+            err
+        })
     .and_then(|modified_vulns| {
         modified_vulns
             .into_iter()
@@ -193,14 +193,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut etag = None;
     let mut safety_cve_map =
         download_and_parse_python_safety_vulns(&PYTHON_SAFETY_VULN_URL, &mut etag, &client)
-            .map_err(|err| {
-                error!(error_logger, "Error downloading Python Safety Vulns";
-                    o!(
-                        "error.message" => err.to_string(),
-                    )
-                );
-                err
-            })?;
+        .map_err(|err| {
+            error!(error_logger, "Error downloading Python Safety Vulns";
+                o!(
+                    "error.message" => err.to_string(),
+                )
+            );
+            err
+        })?;
 
     info!(root_logger, "Successfully got Python dependency vulns from Safety tool database";
         o!(
@@ -214,18 +214,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
     loop {
         if last_updated_time
             .unwrap()
-            .lt(&(Utc::now() - Duration::days(1)))
+                .lt(&(Utc::now() - Duration::days(1)))
         {
             let new_safety_cve_map =
                 download_and_parse_python_safety_vulns(&PYTHON_SAFETY_VULN_URL, &mut etag, &client)
-                    .map_err(|err| {
-                        error!(error_logger, "Error downloading Python Safety Vulns";
-                            o!(
-                                "error.message" => err.to_string(),
-                            )
-                        );
-                        err
-                    })?;
+                .map_err(|err| {
+                    error!(error_logger, "Error downloading Python Safety Vulns";
+                        o!(
+                            "error.message" => err.to_string(),
+                        )
+                    );
+                    err
+                })?;
             if new_safety_cve_map.is_some() {
                 safety_cve_map = new_safety_cve_map;
             }
@@ -233,7 +233,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         if last_updated_time
             .unwrap()
-            .lt(&(Utc::now() - Duration::hours(2)))
+                .lt(&(Utc::now() - Duration::hours(2)))
         {
             download_and_parse_vulns(
                 "modified".to_string(),
@@ -241,14 +241,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 &base_url,
                 &client,
             )
-            .map_err(|err| {
-                error!(error_logger, "Error updating vuln info";
-                    o!(
-                        "error.message" => err.to_string(),
-                    )
-                );
-                err
-            })
+                .map_err(|err| {
+                    error!(error_logger, "Error updating vuln info";
+                        o!(
+                            "error.message" => err.to_string(),
+                        )
+                    );
+                    err
+                })
             .and_then(|modified_vulns| {
                 if let Some(mut modified_vulns) = modified_vulns {
                     for (k, v) in modified_vulns.drain() {
@@ -287,14 +287,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     let app_name = report.application_name.to_string();
                     let records =
                         parse_tool_report(&report, &vulns, safety_cve_map.as_ref().unwrap())
-                            .map_err(|err| {
-                                error!(error_logger, "Error parsing tool output in ToolReport";
-                                    o!(
-                                        "error.message" => err.to_string(),
-                                    )
-                                );
-                                err
-                            })?;
+                        .map_err(|err| {
+                            error!(error_logger, "Error parsing tool output in ToolReport";
+                                o!(
+                                    "error.message" => err.to_string(),
+                                )
+                            );
+                            err
+                        })?;
                     for record in records.into_iter() {
                         let kafka_payload = FutureRecord::to("DependencyEvents")
                             .payload(&record)
@@ -353,13 +353,13 @@ fn download_and_parse_vulns(
         .map_err(|err| {
             Box::new(err_msg(format!("Error downloading {}: {}", meta_filename, err)).compat())
         })
-        .and_then(|resp| {
-            resp.text().map_err(|err| {
-                Box::new(
-                    err_msg(format!("Error reading body of {}: {}", meta_filename, err)).compat(),
-                )
-            })
-        })?;
+    .and_then(|resp| {
+        resp.text().map_err(|err| {
+            Box::new(
+                err_msg(format!("Error reading body of {}: {}", meta_filename, err)).compat(),
+            )
+        })
+    })?;
 
     let last_mod_timestamp = META_LAST_MOD_RE
         .captures(&meta_resp_text)
@@ -367,21 +367,21 @@ fn download_and_parse_vulns(
         .ok_or_else(|| {
             Box::new(
                 err_msg(format!(
-                    "Error reading lastModifiedDate from {}",
-                    meta_filename
+                        "Error reading lastModifiedDate from {}",
+                        meta_filename
                 ))
                 .compat(),
             )
         })
-        .map(|capture| capture.as_str())?;
+    .map(|capture| capture.as_str())?;
 
-    let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
-        .captures(&meta_resp_text)
-        .and_then(|captures| captures.get(1))
-        .ok_or_else(|| {
-            Box::new(err_msg(format!("Error reading size from {}", meta_filename)).compat())
-        })
-        .map(|capture| capture.as_str())?;
+let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
+    .captures(&meta_resp_text)
+    .and_then(|captures| captures.get(1))
+    .ok_or_else(|| {
+        Box::new(err_msg(format!("Error reading size from {}", meta_filename)).compat())
+    })
+.map(|capture| capture.as_str())?;
 
     let compressed_size = META_COMPRESSED_GZ_SIZE_RE
         .captures(&meta_resp_text)
@@ -389,21 +389,21 @@ fn download_and_parse_vulns(
         .ok_or_else(|| {
             Box::new(
                 err_msg(format!(
-                    "Error reading compressed size from {}",
-                    meta_filename
+                        "Error reading compressed size from {}",
+                        meta_filename
                 ))
                 .compat(),
             )
         })
-        .map(|capture| capture.as_str())?;
+    .map(|capture| capture.as_str())?;
 
-    let hash = META_SHA256_RE
-        .captures(&meta_resp_text)
-        .and_then(|captures| captures.get(1))
-        .ok_or_else(|| {
-            Box::new(err_msg(format!("Error reading sha256 hash from {}", meta_filename)).compat())
-        })
-        .map(|capture| capture.as_str())?;
+let hash = META_SHA256_RE
+    .captures(&meta_resp_text)
+    .and_then(|captures| captures.get(1))
+    .ok_or_else(|| {
+        Box::new(err_msg(format!("Error reading sha256 hash from {}", meta_filename)).compat())
+    })
+.map(|capture| capture.as_str())?;
 
     if last_updated_time.is_none()
         || last_updated_time
@@ -434,11 +434,11 @@ fn download_and_parse_vulns(
 
         if hash != computed_hash {
             return Err(Box::new(
-                err_msg(format!(
-                    "Hash mismatch for {}, expected {}, got {}",
-                    data_filename, hash, computed_hash
-                ))
-                .compat(),
+                    err_msg(format!(
+                            "Hash mismatch for {}, expected {}, got {}",
+                            data_filename, hash, computed_hash
+                    ))
+                    .compat(),
             ));
         }
 
@@ -493,9 +493,9 @@ fn download_and_parse_vulns(
 
                 (
                     vuln_info["cve"]["CVE_data_meta"]["ID"]
-                        .as_str()
-                        .unwrap()
-                        .to_string(),
+                    .as_str()
+                    .unwrap()
+                    .to_string(),
                     VulnData {
                         advisory_str: compr_adv_text,
                         advisory_url: adv_url_str.to_string(),
@@ -503,9 +503,9 @@ fn download_and_parse_vulns(
                     },
                 )
             })
-            .collect::<HashMap<_, _>>();
+        .collect::<HashMap<_, _>>();
 
-        return Ok(Some(cve_items));
+    return Ok(Some(cve_items));
     }
 
     Ok(None)
@@ -521,13 +521,13 @@ fn parse_tool_report(
             parse_bundler_audit_plaintext(&report, &vulns)
         } else {
             Err(Box::new(
-                err_msg(format!(
-                    "Unknown output format for Bundler-audit in ToolReport: {:?}",
-                    report
-                ))
-                .compat(),
+                    err_msg(format!(
+                            "Unknown output format for Bundler-audit in ToolReport: {:?}",
+                            report
+                    ))
+                    .compat(),
             )
-            .into())
+                .into())
         }
     } else if report.tool_name == "safety" {
         if report.output_format == "JSON" {
@@ -543,13 +543,13 @@ fn parse_tool_report(
                 .into())
         } else {
             Err(Box::new(
-                err_msg(format!(
-                    "Unknown output format for safety in ToolReport: {:?}",
-                    report
-                ))
-                .compat(),
+                    err_msg(format!(
+                            "Unknown output format for safety in ToolReport: {:?}",
+                            report
+                    ))
+                    .compat(),
             )
-            .into())
+                .into())
         }
     } else {
         Err(Box::new(err_msg(format!("Unknown tool in ToolReport: {:?}", report)).compat()).into())
@@ -591,11 +591,11 @@ fn parse_bundler_audit_plaintext(
             .collect::<HashMap<_, _>>();
         let advisory_id = AdvisoryId::try_from(
             fields
-                .get("Advisory")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+            .get("Advisory")
+            .cloned()
+            .or_else(|| Some("".to_string()))
+            .unwrap()
+            .to_owned(),
         )?;
 
         let cvss = vulns
@@ -612,36 +612,36 @@ fn parse_bundler_audit_plaintext(
             timestamp: Timestamp::try_from(report.end_time.to_string())?,
             affected_package: AffectedPackage::try_from(
                 fields
-                    .get("Name")
-                    .cloned()
-                    .or_else(|| Some("".to_string()))
-                    .unwrap()
-                    .to_owned(),
+                .get("Name")
+                .cloned()
+                .or_else(|| Some("".to_string()))
+                .unwrap()
+                .to_owned(),
             )?,
             installed_version: InstalledVersion::try_from(
                 fields
-                    .get("Version")
-                    .cloned()
-                    .or_else(|| Some("".to_string()))
-                    .unwrap()
-                    .to_owned(),
+                .get("Version")
+                .cloned()
+                .or_else(|| Some("".to_string()))
+                .unwrap()
+                .to_owned(),
             )?,
             advisory_url: AdvisoryUrl::try_from(
                 fields
-                    .get("URL")
-                    .cloned()
-                    .or_else(|| Some("".to_string()))
-                    .unwrap()
-                    .to_owned(),
+                .get("URL")
+                .cloned()
+                .or_else(|| Some("".to_string()))
+                .unwrap()
+                .to_owned(),
             )?,
             advisory_id,
             advisory_description: AdvisoryDescription::try_from(
                 fields
-                    .get("Title")
-                    .cloned()
-                    .or_else(|| Some("".to_owned()))
-                    .unwrap()
-                    .to_owned(),
+                .get("Title")
+                .cloned()
+                .or_else(|| Some("".to_owned()))
+                .unwrap()
+                .to_owned(),
             )?,
             cvss: cvss.clone(),
             suppressed: false,
@@ -714,14 +714,14 @@ fn download_and_parse_python_safety_vulns(
         }
     } else {
         return Err(Box::new(
-            err_msg(format!(
-                "Unable to grab head from python safety database: ({})",
-                head_resp.status()
-            ))
-            .compat(),
+                err_msg(format!(
+                        "Unable to grab head from python safety database: ({})",
+                        head_resp.status()
+                ))
+                .compat(),
         )
-        .into());
-    }
+            .into());
+        }
 
     let safety_db_resp_text = reqwest::blocking::get(safety_json_db_url)?.text()?;
     let python_safety_vuln_info_json: HashMap<String, SafetyJsonData> =
@@ -734,17 +734,17 @@ fn download_and_parse_python_safety_vulns(
             SafetyJsonData::Vuln(_s) => true,
             _ => false,
         })
-        .map(|s| match s {
-            SafetyJsonData::Vuln(s) => s.iter(),
-            _ => unreachable!(),
-        })
-        .flatten()
+    .map(|s| match s {
+        SafetyJsonData::Vuln(s) => s.iter(),
+        _ => unreachable!(),
+    })
+    .flatten()
         .map(|p| match &p.cve {
             Value::String(s) => (p.id.to_owned(), Some(s.to_owned())),
             _ => (p.id.to_owned(), None),
         })
-        .collect::<HashMap<_, _>>();
-    Ok(Some(cve_items))
+    .collect::<HashMap<_, _>>();
+Ok(Some(cve_items))
 }
 
 fn parse_safety_json(
@@ -872,6 +872,8 @@ fn should_issue_be_suppressed(
 mod tests {
     use super::*;
     use httpmock::MockServer;
+    use httpmock::Method::GET;
+    use httpmock::Method::HEAD;
     use kiln_lib::tool_report::{
         ApplicationName, EndTime, Environment, EventID, EventVersion, GitBranch, GitCommitHash,
         IssueHash, OutputFormat, StartTime, SuppressedIssue, ToolName, ToolOutput, ToolReport,
@@ -885,7 +887,7 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
@@ -899,15 +901,15 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![SuppressedIssue {
             issue_hash: IssueHash::try_from(
-                "a441b688fb60942c701fbcee0f30c66c0f7b22da7f0b4c51488488d2a2b64197".to_owned(),
-            )
-            .unwrap(),
-            expiry_date: ExpiryDate::from(None),
-            suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-            suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                            "a441b688fb60942c701fbcee0f30c66c0f7b22da7f0b4c51488488d2a2b64197".to_owned(),
+                        )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
         }];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
@@ -921,26 +923,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 20).and_hms(12, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 20).and_hms(12, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "46a9d5bde718bf366178313019f04a753bad00685d38e3ec81c8628f35dfcb1b".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                                "46a9d5bde718bf366178313019f04a753bad00685d38e3ec81c8628f35dfcb1b".to_owned(),
+                            )
+                    .unwrap(),
+                    expiry_date: ExpiryDate::from(None),
+                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -956,26 +958,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(0, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(0, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "9cf8847d2992e7219e659cdde1969e0d567ebab39a7aba13b36f9916fa26f6ca".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                                "9cf8847d2992e7219e659cdde1969e0d567ebab39a7aba13b36f9916fa26f6ca".to_owned(),
+                            )
+                    .unwrap(),
+                    expiry_date: ExpiryDate::from(None),
+                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -991,26 +993,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 18).and_hms(10, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 18).and_hms(10, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "b100dabbadeedabbad1eadabbadeedabbad1edabbadeedabbad1eadabbadeeda".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                                "b100dabbadeedabbad1eadabbadeedabbad1edabbadeedabbad1eadabbadeeda".to_owned(),
+                            )
+                    .unwrap(),
+                    expiry_date: ExpiryDate::from(None),
+                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -1026,26 +1028,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(None),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "a41f58ced5996b018dfbd697c1b16675f0cf864a3475d237cdd3f4d8c7160fdb".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                                "a41f58ced5996b018dfbd697c1b16675f0cf864a3475d237cdd3f4d8c7160fdb".to_owned(),
+                            )
+                    .unwrap(),
+                    expiry_date: ExpiryDate::from(None),
+                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -1061,29 +1063,29 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 19).and_hms(12, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 19).and_hms(12, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
-        ];
+            ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
             true,
@@ -1097,29 +1099,29 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(12, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(12, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
-        ];
+            ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
             true,
@@ -1138,7 +1140,7 @@ mod tests {
         let client = Client::new();
         assert!(
             download_and_parse_python_safety_vulns(&server.url("/data"), &mut etag, &client)
-                .is_err(),
+            .is_err(),
             "HTTP error status not handled correctly"
         );
         mock.assert_hits(1);
@@ -1148,8 +1150,20 @@ mod tests {
     fn download_safety_vuln_db_etag_none() {
         let mut etag = None;
         let server = MockServer::start();
-        let mock = server.mock(|when, then| {
-            when.any_request();
+        let head_mock = server.mock(|when, then| {
+            when.method(HEAD);
+            then.status(200)
+                .header("Connection", "keep-alive")
+                .header("Content-Length", "708")
+                .header("Content-Type", "text/plain; charset=utf-8")
+                .header("Cache-Control", "max-age=300")
+                .header(
+                    "ETag",
+                    "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
+                );
+        });
+        let get_mock = server.mock(|when, then| {
+            when.method(GET);
             then.status(200)
                 .header("Connection", "keep-alive")
                 .header("Content-Length", "708")
@@ -1244,7 +1258,8 @@ mod tests {
         let value = vhash.get("pyup.io-38552").unwrap();
         assert_eq!(value.as_ref().unwrap(), "CVE-2017-18342");
 
-        mock.assert_hits(2);
+        head_mock.assert_hits(1);
+        get_mock.assert_hits(1);
     }
 
     #[test]
@@ -1253,8 +1268,22 @@ mod tests {
             "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f22\"".to_string(),
         );
         let server = MockServer::start();
-        let mock = server.mock(|when, then| {
-            when.any_request();
+
+        let head_mock = server.mock(|when, then| {
+            when.method(HEAD);
+            then.status(200)
+                .header("Connection", "keep-alive")
+                .header("Content-Length", "708")
+                .header("Content-Type", "text/plain; charset=utf-8")
+                .header("Cache-Control", "max-age=300")
+                .header(
+                    "ETag",
+                    "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d4038a05ba4f26\"",
+                );
+        });
+
+        let get_mock = server.mock(|when, then| {
+            when.method(GET);
             then.status(200)
                 .header("Connection", "keep-alive")
                 .header("Content-Length", "708")
@@ -1351,7 +1380,8 @@ mod tests {
         let value = vhash.get("pyup.io-38552").unwrap();
         assert_eq!(value.as_ref().unwrap(), "CVE-2017-18342");
 
-        mock.assert_hits(2);
+        head_mock.assert_hits(1);
+        get_mock.assert_hits(1);
     }
 
     #[test]
@@ -1360,8 +1390,20 @@ mod tests {
             "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"".to_string(),
         );
         let server = MockServer::start();
-        let mock = server.mock(|when, then| {
-            when.any_request();
+        let head_mock = server.mock(|when, then| {
+            when.method(HEAD);
+            then.status(200)
+                .header("Connection", "keep-alive")
+                .header("Content-Length", "348")
+                .header("Content-Type", "text/plain; charset=utf-8")
+                .header("Cache-Control", "max-age=300")
+                .header(
+                    "ETag",
+                    "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
+                );
+        });
+        let get_mock = server.mock(|when, then| {
+            when.method(GET);
             then.status(200)
                 .header("Connection", "keep-alive")
                 .header("Content-Length", "348")
@@ -1413,7 +1455,8 @@ mod tests {
             res_ok.is_none(),
             "Matching etags should produce a None result"
         );
-        mock.assert_hits(1);
+        head_mock.assert_hits(1);
+        get_mock.assert_hits(0);
     }
 
     #[test]
@@ -1438,51 +1481,51 @@ mod tests {
         null
     ]]"#;
 
-        let advisory_text_1 = "Some advsiory text CVE-2020-13757";
-        let compr_adv_text_1 = ComprString::new(advisory_text_1);
-        let advisory_url_1 = "http://someurl-cve-2020-13757.co.uk/";
+    let advisory_text_1 = "Some advsiory text CVE-2020-13757";
+    let compr_adv_text_1 = ComprString::new(advisory_text_1);
+    let advisory_url_1 = "http://someurl-cve-2020-13757.co.uk/";
 
-        let advisory_text_2 = "Some advsiory text CVE-2020-14564";
-        let compr_adv_text_2 = ComprString::new(advisory_text_2);
-        let advisory_url_2 = "http://someurl-cve-2020-14564.co.uk/";
+    let advisory_text_2 = "Some advsiory text CVE-2020-14564";
+    let compr_adv_text_2 = ComprString::new(advisory_text_2);
+    let advisory_url_2 = "http://someurl-cve-2020-14564.co.uk/";
 
-        let safety_cve_map: HashMap<String, Option<String>> = [(
-            "pyup.io-38414".to_string(),
-            Some("CVE-2020-13757 , CVE-2020-14564".to_string()),
-        )]
+    let safety_cve_map: HashMap<String, Option<String>> = [(
+        "pyup.io-38414".to_string(),
+        Some("CVE-2020-13757 , CVE-2020-14564".to_string()),
+    )]
         .iter()
         .cloned()
         .collect();
 
-        let vulnshash: HashMap<String, VulnData> = [
-            (
-                "CVE-2020-13757".to_string(),
-                VulnData {
-                    advisory_str: compr_adv_text_1,
-                    advisory_url: advisory_url_1.to_string(),
-                    cvss: Cvss::builder()
-                        .with_version(CvssVersion::V2)
-                        .with_score(Some(7.5))
-                        .build()
-                        .unwrap(),
-                },
-            ),
-            (
-                "CVE-2020-14564".to_string(),
-                VulnData {
-                    advisory_str: compr_adv_text_2,
-                    advisory_url: advisory_url_2.to_string(),
-                    cvss: Cvss::builder()
-                        .with_version(CvssVersion::V2)
-                        .with_score(Some(7.5))
-                        .build()
-                        .unwrap(),
-                },
-            ),
+    let vulnshash: HashMap<String, VulnData> = [
+        (
+            "CVE-2020-13757".to_string(),
+            VulnData {
+                advisory_str: compr_adv_text_1,
+                advisory_url: advisory_url_1.to_string(),
+                cvss: Cvss::builder()
+                    .with_version(CvssVersion::V2)
+                    .with_score(Some(7.5))
+                    .build()
+                    .unwrap(),
+            },
+        ),
+        (
+            "CVE-2020-14564".to_string(),
+            VulnData {
+                advisory_str: compr_adv_text_2,
+                advisory_url: advisory_url_2.to_string(),
+                cvss: Cvss::builder()
+                    .with_version(CvssVersion::V2)
+                    .with_score(Some(7.5))
+                    .build()
+                    .unwrap(),
+            },
+        ),
         ]
-        .iter()
-        .cloned()
-        .collect();
+            .iter()
+            .cloned()
+            .collect();
         let test_report = ToolReport {
             event_version: EventVersion::try_from("1".to_owned()).unwrap(),
             event_id: EventID::try_from("95130bee-95ae-4dac-aecf-5650ff646ea1".to_owned()).unwrap(),
@@ -1491,19 +1534,19 @@ mod tests {
             git_commit_hash: GitCommitHash::try_from(
                 "e99f715d0fe787cd43de967b8a79b56960fed3e5".to_owned(),
             )
-            .unwrap(),
-            tool_name: ToolName::try_from("safety".to_owned()).unwrap(),
-            tool_output: ToolOutput::try_from(python_safety_vulns.to_owned()).unwrap(),
-            output_format: OutputFormat::JSON,
-            start_time: StartTime::from(DateTime::<Utc>::from(
-                DateTime::parse_from_rfc3339("2019-09-13T19:35:38+00:00").unwrap(),
-            )),
-            end_time: EndTime::from(DateTime::<Utc>::from(
-                DateTime::parse_from_rfc3339("2019-09-13T19:37:14+00:00").unwrap(),
-            )),
-            environment: Environment::Local,
-            tool_version: ToolVersion::try_from(Some("1.0".to_owned())).unwrap(),
-            suppressed_issues: vec![],
+                .unwrap(),
+                tool_name: ToolName::try_from("safety".to_owned()).unwrap(),
+                tool_output: ToolOutput::try_from(python_safety_vulns.to_owned()).unwrap(),
+                output_format: OutputFormat::JSON,
+                start_time: StartTime::from(DateTime::<Utc>::from(
+                        DateTime::parse_from_rfc3339("2019-09-13T19:35:38+00:00").unwrap(),
+                )),
+                end_time: EndTime::from(DateTime::<Utc>::from(
+                        DateTime::parse_from_rfc3339("2019-09-13T19:37:14+00:00").unwrap(),
+                )),
+                environment: Environment::Local,
+                tool_version: ToolVersion::try_from(Some("1.0".to_owned())).unwrap(),
+                suppressed_issues: vec![],
         };
         let events_res = parse_safety_json(&test_report, &vulnshash, &safety_cve_map);
         assert!(events_res.is_ok());

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -130,7 +130,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .build()?;
 
     let mut vulns = HashMap::new();
-    let mut safety_cve_map = HashMap::new();
     for year in 2002..=Utc::today().year() {
         download_and_parse_vulns(year.to_string(), last_updated_time, &base_url, &client)
             .map_err(|err| {

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -697,8 +697,7 @@ fn download_and_parse_python_safety_vulns(
     etag: &mut Option<String>,
     client: &Client,
 ) -> Result<Option<HashMap<String, Option<String>>>, Box<dyn Error>> {
-    let safety_json_db_url = &server_name.to_string();
-    let head_resp = client.head(safety_json_db_url).send()?;
+    let head_resp = client.head(server_name).send()?;
     let mut etag_str = None;
     if head_resp.status().is_success() {
         if let Some(etag_new) = head_resp.headers().get(ETAG) {

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -720,9 +720,9 @@ fn download_and_parse_python_safety_vulns(
         .into());
     }
 
-    let meta_resp_text = reqwest::blocking::get(safety_json_db_url)?.text()?;
+    let safety_db_resp_text = reqwest::blocking::get(safety_json_db_url)?.text()?;
     let python_safety_vuln_info_json: HashMap<String, SafetyJsonData> =
-        serde_json::from_str(meta_resp_text.as_ref())?;
+        serde_json::from_str(safety_db_resp_text.as_ref())?;
     let cve_items = python_safety_vuln_info_json
         .values()
         .filter(|ref _s| match _s {
@@ -733,11 +733,7 @@ fn download_and_parse_python_safety_vulns(
             SafetyJsonData::Vuln(s) => s.iter(),
             _ => unreachable!(),
         })
-        .collect::<Vec<_>>()
-        .into_iter()
         .flatten()
-        .collect::<Vec<_>>()
-        .iter()
         .map(|p| match &p.cve {
             Value::String(s) => (p.id.to_owned(), Some(s.to_owned())),
             _ => (p.id.to_owned(), None),

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -53,7 +53,8 @@ use uuid::Uuid;
 use httpmock::MockServer;
 
 const SERVICE_NAME: &str = "report-parser";
-const PYTHON_SAFETY_VULN_URL: &str ="https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json";
+const PYTHON_SAFETY_VULN_URL: &str =
+    "https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -83,7 +84,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 Uuid::new_v4().to_hyphenated().to_string()
             }),
         ),
-        );
+    );
 
     let error_logger = root_logger.new(o!("event.type" => EventType(vec!("error".to_string()))));
 
@@ -126,7 +127,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let base_url = Url::parse(
         &env::var("NVD_BASE_URL")
-        .unwrap_or_else(|_| "https://nvd.nist.gov/feeds/json/cve/1.1/".to_string()),
+            .unwrap_or_else(|_| "https://nvd.nist.gov/feeds/json/cve/1.1/".to_string()),
     )?;
     let mut last_updated_time = None;
     let client_builder = Client::builder();
@@ -146,23 +147,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 );
                 err
             })
-        .and_then(|parsed_vulns| {
-            parsed_vulns
-                .into_iter()
-                .fold(&mut vulns, |acc, mut values| {
-                    for (k, v) in values.drain() {
-                        acc.insert(k, v);
-                    }
-                    acc
-                });
-            info!(root_logger, "Successfully got vulns for {}", year;
-                o!(
-                    "event.type" => EventType(vec!("info".to_string())),
-                )
-            );
-            Ok(())
-        })?;
-            }
+            .and_then(|parsed_vulns| {
+                parsed_vulns
+                    .into_iter()
+                    .fold(&mut vulns, |acc, mut values| {
+                        for (k, v) in values.drain() {
+                            acc.insert(k, v);
+                        }
+                        acc
+                    });
+                info!(root_logger, "Successfully got vulns for {}", year;
+                    o!(
+                        "event.type" => EventType(vec!("info".to_string())),
+                    )
+                );
+                Ok(())
+            })?;
+    }
 
     download_and_parse_vulns(
         "modified".to_string(),
@@ -170,14 +171,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &base_url,
         &client,
     )
-        .map_err(|err| {
-            error!(error_logger, "Error downloading modified vulns info";
-                o!(
-                    "error.message" => err.to_string(),
-                )
-            );
-            err
-        })
+    .map_err(|err| {
+        error!(error_logger, "Error downloading modified vulns info";
+            o!(
+                "error.message" => err.to_string(),
+            )
+        );
+        err
+    })
     .and_then(|modified_vulns| {
         modified_vulns
             .into_iter()
@@ -198,17 +199,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut etag = None;
     let safety_json_db_url =
         "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json"
-        .to_string();
+            .to_string();
     let mut safety_cve_map =
         download_and_parse_python_safety_vulns(safety_json_db_url.clone(), &mut etag, &client)
-        .map_err(|err| {
-            error!(error_logger, "Error downloading Python Safety Vulns";
-                o!(
-                    "error.message" => err.to_string(),
-                )
-            );
-            err
-        })?;
+            .map_err(|err| {
+                error!(error_logger, "Error downloading Python Safety Vulns";
+                    o!(
+                        "error.message" => err.to_string(),
+                    )
+                );
+                err
+            })?;
 
     last_updated_time = Some(Utc::now());
 
@@ -217,21 +218,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
     loop {
         if last_updated_time
             .unwrap()
-                .lt(&(Utc::now() - Duration::days(1)))
+            .lt(&(Utc::now() - Duration::days(1)))
         {
             let new_safety_cve_map = download_and_parse_python_safety_vulns(
                 safety_json_db_url.clone(),
                 &mut etag,
                 &client,
             )
-                .map_err(|err| {
-                    error!(error_logger, "Error downloading Python Safety Vulns";
-                        o!(
-                            "error.message" => err.to_string(),
-                        )
-                    );
-                    err
-                })?;
+            .map_err(|err| {
+                error!(error_logger, "Error downloading Python Safety Vulns";
+                    o!(
+                        "error.message" => err.to_string(),
+                    )
+                );
+                err
+            })?;
             if new_safety_cve_map.is_some() {
                 safety_cve_map = new_safety_cve_map;
             }
@@ -239,7 +240,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         if last_updated_time
             .unwrap()
-                .lt(&(Utc::now() - Duration::hours(2)))
+            .lt(&(Utc::now() - Duration::hours(2)))
         {
             download_and_parse_vulns(
                 "modified".to_string(),
@@ -247,14 +248,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 &base_url,
                 &client,
             )
-                .map_err(|err| {
-                    error!(error_logger, "Error updating vuln info";
-                        o!(
-                            "error.message" => err.to_string(),
-                        )
-                    );
-                    err
-                })
+            .map_err(|err| {
+                error!(error_logger, "Error updating vuln info";
+                    o!(
+                        "error.message" => err.to_string(),
+                    )
+                );
+                err
+            })
             .and_then(|modified_vulns| {
                 if let Some(mut modified_vulns) = modified_vulns {
                     for (k, v) in modified_vulns.drain() {
@@ -293,14 +294,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     let app_name = report.application_name.to_string();
                     let records =
                         parse_tool_report(&report, &vulns, safety_cve_map.as_ref().unwrap())
-                        .map_err(|err| {
-                            error!(error_logger, "Error parsing tool output in ToolReport";
-                                o!(
-                                    "error.message" => err.to_string(),
-                                )
-                            );
-                            err
-                        })?;
+                            .map_err(|err| {
+                                error!(error_logger, "Error parsing tool output in ToolReport";
+                                    o!(
+                                        "error.message" => err.to_string(),
+                                    )
+                                );
+                                err
+                            })?;
                     for record in records.into_iter() {
                         let kafka_payload = FutureRecord::to("DependencyEvents")
                             .payload(&record)
@@ -359,13 +360,13 @@ fn download_and_parse_vulns(
         .map_err(|err| {
             Box::new(err_msg(format!("Error downloading {}: {}", meta_filename, err)).compat())
         })
-    .and_then(|resp| {
-        resp.text().map_err(|err| {
-            Box::new(
-                err_msg(format!("Error reading body of {}: {}", meta_filename, err)).compat(),
-            )
-        })
-    })?;
+        .and_then(|resp| {
+            resp.text().map_err(|err| {
+                Box::new(
+                    err_msg(format!("Error reading body of {}: {}", meta_filename, err)).compat(),
+                )
+            })
+        })?;
 
     let last_mod_timestamp = META_LAST_MOD_RE
         .captures(&meta_resp_text)
@@ -373,21 +374,21 @@ fn download_and_parse_vulns(
         .ok_or_else(|| {
             Box::new(
                 err_msg(format!(
-                        "Error reading lastModifiedDate from {}",
-                        meta_filename
+                    "Error reading lastModifiedDate from {}",
+                    meta_filename
                 ))
                 .compat(),
             )
         })
-    .map(|capture| capture.as_str())?;
+        .map(|capture| capture.as_str())?;
 
-let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
-    .captures(&meta_resp_text)
-    .and_then(|captures| captures.get(1))
-    .ok_or_else(|| {
-        Box::new(err_msg(format!("Error reading size from {}", meta_filename)).compat())
-    })
-.map(|capture| capture.as_str())?;
+    let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
+        .captures(&meta_resp_text)
+        .and_then(|captures| captures.get(1))
+        .ok_or_else(|| {
+            Box::new(err_msg(format!("Error reading size from {}", meta_filename)).compat())
+        })
+        .map(|capture| capture.as_str())?;
 
     let compressed_size = META_COMPRESSED_GZ_SIZE_RE
         .captures(&meta_resp_text)
@@ -395,21 +396,21 @@ let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
         .ok_or_else(|| {
             Box::new(
                 err_msg(format!(
-                        "Error reading compressed size from {}",
-                        meta_filename
+                    "Error reading compressed size from {}",
+                    meta_filename
                 ))
                 .compat(),
             )
         })
-    .map(|capture| capture.as_str())?;
+        .map(|capture| capture.as_str())?;
 
-let hash = META_SHA256_RE
-    .captures(&meta_resp_text)
-    .and_then(|captures| captures.get(1))
-    .ok_or_else(|| {
-        Box::new(err_msg(format!("Error reading sha256 hash from {}", meta_filename)).compat())
-    })
-.map(|capture| capture.as_str())?;
+    let hash = META_SHA256_RE
+        .captures(&meta_resp_text)
+        .and_then(|captures| captures.get(1))
+        .ok_or_else(|| {
+            Box::new(err_msg(format!("Error reading sha256 hash from {}", meta_filename)).compat())
+        })
+        .map(|capture| capture.as_str())?;
 
     if last_updated_time.is_none()
         || last_updated_time
@@ -440,11 +441,11 @@ let hash = META_SHA256_RE
 
         if hash != computed_hash {
             return Err(Box::new(
-                    err_msg(format!(
-                            "Hash mismatch for {}, expected {}, got {}",
-                            data_filename, hash, computed_hash
-                    ))
-                    .compat(),
+                err_msg(format!(
+                    "Hash mismatch for {}, expected {}, got {}",
+                    data_filename, hash, computed_hash
+                ))
+                .compat(),
             ));
         }
 
@@ -501,9 +502,9 @@ let hash = META_SHA256_RE
 
                 (
                     vuln_info["cve"]["CVE_data_meta"]["ID"]
-                    .as_str()
-                    .unwrap()
-                    .to_string(),
+                        .as_str()
+                        .unwrap()
+                        .to_string(),
                     VulnData {
                         advisory_str: compr_adv_text,
                         advisory_url: adv_url,
@@ -511,9 +512,9 @@ let hash = META_SHA256_RE
                     },
                 )
             })
-        .collect::<HashMap<_, _>>();
+            .collect::<HashMap<_, _>>();
 
-    return Ok(Some(cve_items));
+        return Ok(Some(cve_items));
     }
 
     Ok(None)
@@ -529,13 +530,13 @@ fn parse_tool_report(
             parse_bundler_audit_plaintext(&report, &vulns)
         } else {
             Err(Box::new(
-                    err_msg(format!(
-                            "Unknown output format for Bundler-audit in ToolReport: {:?}",
-                            report
-                    ))
-                    .compat(),
+                err_msg(format!(
+                    "Unknown output format for Bundler-audit in ToolReport: {:?}",
+                    report
+                ))
+                .compat(),
             )
-                .into())
+            .into())
         }
     } else if report.tool_name == "safety" {
         if report.output_format == "JSON" {
@@ -551,13 +552,13 @@ fn parse_tool_report(
                 .into())
         } else {
             Err(Box::new(
-                    err_msg(format!(
-                            "Unknown output format for safety in ToolReport: {:?}",
-                            report
-                    ))
-                    .compat(),
+                err_msg(format!(
+                    "Unknown output format for safety in ToolReport: {:?}",
+                    report
+                ))
+                .compat(),
             )
-                .into())
+            .into())
         }
     } else {
         Err(Box::new(err_msg(format!("Unknown tool in ToolReport: {:?}", report)).compat()).into())
@@ -593,11 +594,11 @@ fn parse_bundler_audit_plaintext(
             .collect::<HashMap<_, _>>();
         let advisory_id = AdvisoryId::try_from(
             fields
-            .get("Advisory")
-            .cloned()
-            .or_else(|| Some("".to_string()))
-            .unwrap()
-            .to_owned(),
+                .get("Advisory")
+                .cloned()
+                .or_else(|| Some("".to_string()))
+                .unwrap()
+                .to_owned(),
         )?;
 
         let default_cvss = Cvss::builder()
@@ -619,36 +620,36 @@ fn parse_bundler_audit_plaintext(
             timestamp: Timestamp::try_from(report.end_time.to_string())?,
             affected_package: AffectedPackage::try_from(
                 fields
-                .get("Name")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+                    .get("Name")
+                    .cloned()
+                    .or_else(|| Some("".to_string()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             installed_version: InstalledVersion::try_from(
                 fields
-                .get("Version")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+                    .get("Version")
+                    .cloned()
+                    .or_else(|| Some("".to_string()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             advisory_url: AdvisoryUrl::try_from(
                 fields
-                .get("URL")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+                    .get("URL")
+                    .cloned()
+                    .or_else(|| Some("".to_string()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             advisory_id,
             advisory_description: AdvisoryDescription::try_from(
                 fields
-                .get("Title")
-                .cloned()
-                .or_else(|| Some("".to_owned()))
-                .unwrap()
-                .to_owned(),
+                    .get("Title")
+                    .cloned()
+                    .or_else(|| Some("".to_owned()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             cvss: cvss.clone(),
             suppressed: false,
@@ -718,14 +719,14 @@ fn download_and_parse_python_safety_vulns(
         }
     } else {
         return Err(Box::new(
-                err_msg(format!(
-                        "Unable to grab head from python safety database: ({})",
-                        head_resp.status()
-                ))
-                .compat(),
+            err_msg(format!(
+                "Unable to grab head from python safety database: ({})",
+                head_resp.status()
+            ))
+            .compat(),
         )
-            .into());
-        }
+        .into());
+    }
 
     let meta_resp_text = reqwest::blocking::get(safety_json_db_url)?.text()?;
     let python_safety_vuln_info_json: HashMap<String, SafetyJsonData> =
@@ -736,11 +737,11 @@ fn download_and_parse_python_safety_vulns(
             SafetyJsonData::Vuln(_s) => true,
             _ => false,
         })
-    .map(|s| match s {
-        SafetyJsonData::Vuln(s) => s.iter(),
-        _ => unreachable!(),
-    })
-    .collect::<Vec<_>>()
+        .map(|s| match s {
+            SafetyJsonData::Vuln(s) => s.iter(),
+            _ => unreachable!(),
+        })
+        .collect::<Vec<_>>()
         .into_iter()
         .flatten()
         .collect::<Vec<_>>()
@@ -749,8 +750,8 @@ fn download_and_parse_python_safety_vulns(
             Value::String(s) => (p.id.to_owned(), Some(s.to_owned())),
             _ => (p.id.to_owned(), None),
         })
-    .collect::<HashMap<_, _>>();
-Ok(Some(cve_items))
+        .collect::<HashMap<_, _>>();
+    Ok(Some(cve_items))
 }
 
 fn parse_safety_json(
@@ -772,30 +773,28 @@ fn parse_safety_json(
         let mut advisory_url = PYTHON_SAFETY_VULN_URL.to_string();
         let mut cvss = &default_cvss;
 
-        match safety_vulns
-            .get(&format!("pyup.io-{}", advisory_id.to_string()))
-            {
-                Some(res) => 
-                    match res { 
-                        Some(s) => {
-                            let cve_vec = s.split(',').collect::<Vec<&str>>();
-                            for cve_str in cve_vec {
-                                cvss = vulns.get(cve_str).map_or(&default_cvss, |v| &v.cvss);
-                                advisory_str = vulns
-                                    .get(cve_str)
-                                    .map_or(vuln.advisory_description.to_string(), |v| {
-                                        v.advisory_str.to_string()
-                                    });
-                                advisory_url = vulns.get(cve_str).map_or(
-                                    PYTHON_SAFETY_VULN_URL.to_string(),
-                                    |v| v.advisory_url.to_string(),
-                                );
-                            }
-                        }
-                        _ => (),
-                    },
-                None => ()
-            };
+        match safety_vulns.get(&format!("pyup.io-{}", advisory_id.to_string())) {
+            Some(res) => match res {
+                Some(s) => {
+                    let cve_vec = s.split(',').collect::<Vec<&str>>();
+                    for cve_str in cve_vec {
+                        cvss = vulns.get(cve_str).map_or(&default_cvss, |v| &v.cvss);
+                        advisory_str = vulns
+                            .get(cve_str)
+                            .map_or(vuln.advisory_description.to_string(), |v| {
+                                v.advisory_str.to_string()
+                            });
+                        advisory_url = vulns
+                            .get(cve_str)
+                            .map_or(PYTHON_SAFETY_VULN_URL.to_string(), |v| {
+                                v.advisory_url.to_string()
+                            });
+                    }
+                }
+                _ => (),
+            },
+            None => (),
+        };
         let mut event = DependencyEvent {
             event_version: EventVersion::try_from("1".to_string())?,
             event_id: EventID::try_from(Uuid::new_v4().to_hyphenated().to_string())?,
@@ -857,7 +856,7 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
@@ -871,15 +870,15 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![SuppressedIssue {
             issue_hash: IssueHash::try_from(
-                            "a441b688fb60942c701fbcee0f30c66c0f7b22da7f0b4c51488488d2a2b64197".to_owned(),
-                        )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                "a441b688fb60942c701fbcee0f30c66c0f7b22da7f0b4c51488488d2a2b64197".to_owned(),
+            )
+            .unwrap(),
+            expiry_date: ExpiryDate::from(None),
+            suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+            suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
         }];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
@@ -893,26 +892,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 20).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 20).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "46a9d5bde718bf366178313019f04a753bad00685d38e3ec81c8628f35dfcb1b".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "46a9d5bde718bf366178313019f04a753bad00685d38e3ec81c8628f35dfcb1b".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -928,26 +927,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(0, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(0, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "9cf8847d2992e7219e659cdde1969e0d567ebab39a7aba13b36f9916fa26f6ca".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "9cf8847d2992e7219e659cdde1969e0d567ebab39a7aba13b36f9916fa26f6ca".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -963,26 +962,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 18).and_hms(10, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 18).and_hms(10, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "b100dabbadeedabbad1eadabbadeedabbad1edabbadeedabbad1eadabbadeeda".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "b100dabbadeedabbad1eadabbadeedabbad1edabbadeedabbad1eadabbadeeda".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -998,26 +997,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "a41f58ced5996b018dfbd697c1b16675f0cf864a3475d237cdd3f4d8c7160fdb".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "a41f58ced5996b018dfbd697c1b16675f0cf864a3475d237cdd3f4d8c7160fdb".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -1033,29 +1032,29 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 19).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 19).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
-            ];
+        ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
             true,
@@ -1069,29 +1068,29 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
-            ];
+        ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
             true,
@@ -1110,7 +1109,7 @@ mod tests {
         let client = Client::new();
         assert!(
             download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client)
-            .is_err(),
+                .is_err(),
             "HTTP error status not handled correctly"
         );
         mock.assert_hits(1);
@@ -1166,7 +1165,9 @@ mod tests {
         let client = Client::new();
         let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
         assert!(etag.is_some());
-        assert!(etag.unwrap() == "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"");
+        assert!(
+            etag.unwrap() == "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\""
+        );
         assert!(
             res.is_ok(),
             "Error result was produced when dealing with a None Etag"
@@ -1192,8 +1193,9 @@ mod tests {
 
     #[test]
     fn download_safety_vuln_db_etags_diff() {
-        let mut etag =
-            Some("\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f22\"".to_string());
+        let mut etag = Some(
+            "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f22\"".to_string(),
+        );
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.any_request();
@@ -1239,8 +1241,13 @@ mod tests {
         let old_etag = etag.clone();
         let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
         assert!(etag.is_some());
-        assert!(old_etag.unwrap() != etag.clone().unwrap(), "Etags cannot be matching");
-        assert!(etag.unwrap() == "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d4038a05ba4f26\"");
+        assert!(
+            old_etag.unwrap() != etag.clone().unwrap(),
+            "Etags cannot be matching"
+        );
+        assert!(
+            etag.unwrap() == "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d4038a05ba4f26\""
+        );
         assert!(
             res.is_ok(),
             "Error result was produced when dealing with matching Etags"
@@ -1266,8 +1273,9 @@ mod tests {
 
     #[test]
     fn download_safety_vuln_db_etags_matching() {
-        let mut etag =
-            Some("\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"".to_string());
+        let mut etag = Some(
+            "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"".to_string(),
+        );
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.any_request();
@@ -1343,63 +1351,63 @@ mod tests {
         "38100"
     ]]"#;
 
-    let advisory_text = "Some advsiory text"; 
-    let compr_adv_text = ComprString::new(advisory_text);
-    let advisory_url = "http://someurl.co.uk/";
+        let advisory_text = "Some advsiory text";
+        let compr_adv_text = ComprString::new(advisory_text);
+        let advisory_url = "http://someurl.co.uk/";
 
-    let safety_cve_map: HashMap<String, Option<String>> = [(
-        "pyup.io-38414".to_string(),
-        Some("CVE-2020-13757".to_string()),
-    )]
+        let safety_cve_map: HashMap<String, Option<String>> = [(
+            "pyup.io-38414".to_string(),
+            Some("CVE-2020-13757".to_string()),
+        )]
         .iter()
         .cloned()
         .collect();
 
-    let vulnshash: HashMap<String, VulnData> = [(
-        "CVE-2020-13757".to_string(),
-        VulnData {
-            advisory_str: compr_adv_text,
-            advisory_url: advisory_url.to_string(),
-            cvss: Cvss::builder()
-                .with_version(CvssVersion::V2)
-                .with_score(Some(7.5))
-                .build()
-                .unwrap(),
-        },
-    )]
+        let vulnshash: HashMap<String, VulnData> = [(
+            "CVE-2020-13757".to_string(),
+            VulnData {
+                advisory_str: compr_adv_text,
+                advisory_url: advisory_url.to_string(),
+                cvss: Cvss::builder()
+                    .with_version(CvssVersion::V2)
+                    .with_score(Some(7.5))
+                    .build()
+                    .unwrap(),
+            },
+        )]
         .iter()
         .cloned()
         .collect();
-    let test_report = ToolReport {
-        event_version: EventVersion::try_from("1".to_owned()).unwrap(),
-        event_id: EventID::try_from("95130bee-95ae-4dac-aecf-5650ff646ea1".to_owned()).unwrap(),
-        application_name: ApplicationName::try_from("Test application".to_owned()).unwrap(),
-        git_branch: GitBranch::try_from(Some("git".to_owned())).unwrap(),
-        git_commit_hash: GitCommitHash::try_from(
-            "e99f715d0fe787cd43de967b8a79b56960fed3e5".to_owned(),
-        )
+        let test_report = ToolReport {
+            event_version: EventVersion::try_from("1".to_owned()).unwrap(),
+            event_id: EventID::try_from("95130bee-95ae-4dac-aecf-5650ff646ea1".to_owned()).unwrap(),
+            application_name: ApplicationName::try_from("Test application".to_owned()).unwrap(),
+            git_branch: GitBranch::try_from(Some("git".to_owned())).unwrap(),
+            git_commit_hash: GitCommitHash::try_from(
+                "e99f715d0fe787cd43de967b8a79b56960fed3e5".to_owned(),
+            )
             .unwrap(),
             tool_name: ToolName::try_from("safety".to_owned()).unwrap(),
             tool_output: ToolOutput::try_from(python_safety_vulns.to_owned()).unwrap(),
             output_format: OutputFormat::JSON,
             start_time: StartTime::from(DateTime::<Utc>::from(
-                    DateTime::parse_from_rfc3339("2019-09-13T19:35:38+00:00").unwrap(),
+                DateTime::parse_from_rfc3339("2019-09-13T19:35:38+00:00").unwrap(),
             )),
             end_time: EndTime::from(DateTime::<Utc>::from(
-                    DateTime::parse_from_rfc3339("2019-09-13T19:37:14+00:00").unwrap(),
+                DateTime::parse_from_rfc3339("2019-09-13T19:37:14+00:00").unwrap(),
             )),
             environment: Environment::Local,
             tool_version: ToolVersion::try_from(Some("1.0".to_owned())).unwrap(),
             suppressed_issues: vec![],
-    };
-    let events_res = parse_safety_json(&test_report, &vulnshash, &safety_cve_map);
-    assert!(events_res.is_ok());
-    let events = events_res.unwrap();
-    assert_eq!(events.len(), 2);
-    assert!(events[0].affected_package.to_string() == "rsa");
-    assert!(events[0].advisory_url.to_string() == advisory_url);
-    assert!(events[0].advisory_description.to_string() == advisory_text); 
-    assert!(events[1].affected_package.to_string() == "pyyaml");
-    assert!(events[1].advisory_url.to_string() == PYTHON_SAFETY_VULN_URL);
+        };
+        let events_res = parse_safety_json(&test_report, &vulnshash, &safety_cve_map);
+        assert!(events_res.is_ok());
+        let events = events_res.unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(events[0].affected_package.to_string() == "rsa");
+        assert!(events[0].advisory_url.to_string() == advisory_url);
+        assert!(events[0].advisory_description.to_string() == advisory_text);
+        assert!(events[1].affected_package.to_string() == "pyyaml");
+        assert!(events[1].advisory_url.to_string() == PYTHON_SAFETY_VULN_URL);
     }
 }

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -480,7 +480,7 @@ fn download_and_parse_vulns(
                     .and_then(|cve| cve.get("description"))
                     .and_then(|desc| desc.get("description_data"));
 
-                let adv = desc_data_arr.unwrap()[0]["value"].as_str().unwrap_or("");
+                let adv = desc_data_arr.filter(|x| x["value"]=="en").unwrap()[0]["value"].as_str().unwrap_or("");
 
                 let compr_adv_text = ComprString::new(&adv);
 

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -7,6 +7,7 @@ use avro_rs::{Reader, Schema, Writer};
 use chrono::prelude::*;
 use chrono::Duration;
 use chrono::{SecondsFormat, Utc};
+use compressed_string::ComprString;
 use data_encoding::HEXUPPER;
 use failure::err_msg;
 use flate2::read::GzDecoder;
@@ -19,17 +20,21 @@ use kiln_lib::dependency_event::{
 };
 use kiln_lib::kafka::*;
 use kiln_lib::log::NestedJsonFmt;
-use kiln_lib::tool_report::{EventID, EventVersion, IssueHash, SuppressedIssue, ToolReport, GitBranch, ApplicationName, ToolName, ToolOutput, Environment, StartTime, EndTime, OutputFormat, GitCommitHash, ToolVersion};
+use kiln_lib::tool_report::{
+    ApplicationName, EndTime, Environment, EventID, EventVersion, GitBranch, GitCommitHash,
+    IssueHash, OutputFormat, StartTime, SuppressedIssue, ToolName, ToolOutput, ToolReport,
+    ToolVersion
+};
 use kiln_lib::traits::Hashable;
 use rdkafka::consumer::{CommitMode, Consumer};
 use rdkafka::message::Message;
 use rdkafka::producer::future_producer::FutureRecord;
 use regex::Regex;
-use reqwest::header::ETAG;
 use reqwest::blocking::Client;
+use reqwest::header::ETAG;
 use ring::digest;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::boxed::Box;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -37,7 +42,6 @@ use std::env;
 use std::error::Error;
 use std::io::Read;
 use std::str::FromStr;
-use compressed_string::ComprString;
 use url::Url;
 
 use slog::o;
@@ -47,7 +51,6 @@ use slog_derive::SerdeValue;
 use uuid::Uuid;
 
 use httpmock::MockServer;
-
 
 const SERVICE_NAME: &str = "report-parser";
 
@@ -79,7 +82,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 Uuid::new_v4().to_hyphenated().to_string()
             }),
         ),
-        );
+    );
 
     let error_logger = root_logger.new(o!("event.type" => EventType(vec!("error".to_string()))));
 
@@ -122,7 +125,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let base_url = Url::parse(
         &env::var("NVD_BASE_URL")
-        .unwrap_or_else(|_| "https://nvd.nist.gov/feeds/json/cve/1.1/".to_string()),
+            .unwrap_or_else(|_| "https://nvd.nist.gov/feeds/json/cve/1.1/".to_string()),
     )?;
     let mut last_updated_time = None;
     let client_builder = Client::builder();
@@ -142,23 +145,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 );
                 err
             })
-        .and_then(|parsed_vulns| {
-            parsed_vulns
-                .into_iter()
-                .fold(&mut vulns, |acc, mut values| {
-                    for (k, v) in values.drain() {
-                        acc.insert(k, v);
-                    }
-                    acc
-                });
-            info!(root_logger, "Successfully got vulns for {}", year;
-                o!(
-                    "event.type" => EventType(vec!("info".to_string())),
-                )
-            );
-            Ok(())
-        })?;
-            }
+            .and_then(|parsed_vulns| {
+                parsed_vulns
+                    .into_iter()
+                    .fold(&mut vulns, |acc, mut values| {
+                        for (k, v) in values.drain() {
+                            acc.insert(k, v);
+                        }
+                        acc
+                    });
+                info!(root_logger, "Successfully got vulns for {}", year;
+                    o!(
+                        "event.type" => EventType(vec!("info".to_string())),
+                    )
+                );
+                Ok(())
+            })?;
+    }
 
     download_and_parse_vulns(
         "modified".to_string(),
@@ -166,14 +169,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &base_url,
         &client,
     )
-        .map_err(|err| {
-            error!(error_logger, "Error downloading modified vulns info";
-                o!(
-                    "error.message" => err.to_string(),
-                )
-            );
-            err
-        })
+    .map_err(|err| {
+        error!(error_logger, "Error downloading modified vulns info";
+            o!(
+                "error.message" => err.to_string(),
+            )
+        );
+        err
+    })
     .and_then(|modified_vulns| {
         modified_vulns
             .into_iter()
@@ -191,44 +194,51 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Ok(())
     })?;
 
-    let mut etag = None; 
-    let safety_json_db_url = "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json".to_string(); 
-    let mut safety_cve_map = download_and_parse_python_safety_vulns(safety_json_db_url.clone(), &mut etag, &client)
-        .map_err(|err| { 
-            error!(error_logger, "Error downloading Python Safety Vulns"; 
-                o!(
-                    "error.message" => err.to_string(),
-                )
-            );
-            err
-        })?;
+    let mut etag = None;
+    let safety_json_db_url =
+        "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json"
+            .to_string();
+    let mut safety_cve_map =
+        download_and_parse_python_safety_vulns(safety_json_db_url.clone(), &mut etag, &client)
+            .map_err(|err| {
+                error!(error_logger, "Error downloading Python Safety Vulns";
+                    o!(
+                        "error.message" => err.to_string(),
+                    )
+                );
+                err
+            })?;
 
     last_updated_time = Some(Utc::now());
 
     let mut messages = consumer.start_with(std::time::Duration::from_secs(1), false);
 
     loop {
+        if last_updated_time
+            .unwrap()
+            .lt(&(Utc::now() - Duration::days(1)))
+        {
+            let new_safety_cve_map = download_and_parse_python_safety_vulns(
+                safety_json_db_url.clone(),
+                &mut etag,
+                &client,
+            )
+            .map_err(|err| {
+                error!(error_logger, "Error downloading Python Safety Vulns";
+                    o!(
+                        "error.message" => err.to_string(),
+                    )
+                );
+                err
+            })?;
+            if new_safety_cve_map.is_some() {
+                safety_cve_map = new_safety_cve_map;
+            }
+        }
 
         if last_updated_time
             .unwrap()
-                .lt(&(Utc::now() - Duration::days(1))) { 
-                    let new_safety_cve_map = download_and_parse_python_safety_vulns(safety_json_db_url.clone(), &mut etag, &client)
-                        .map_err(|err| { 
-                            error!(error_logger, "Error downloading Python Safety Vulns"; 
-                                o!(
-                                    "error.message" => err.to_string(),
-                                )
-                            );
-                            err
-                        })?; 
-                    if new_safety_cve_map.is_some() { 
-                        safety_cve_map = new_safety_cve_map;
-                    } 
-                }
-
-        if last_updated_time
-            .unwrap()
-                .lt(&(Utc::now() - Duration::hours(2)))
+            .lt(&(Utc::now() - Duration::hours(2)))
         {
             download_and_parse_vulns(
                 "modified".to_string(),
@@ -236,14 +246,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 &base_url,
                 &client,
             )
-                .map_err(|err| {
-                    error!(error_logger, "Error updating vuln info";
-                        o!(
-                            "error.message" => err.to_string(),
-                        )
-                    );
-                    err
-                })
+            .map_err(|err| {
+                error!(error_logger, "Error updating vuln info";
+                    o!(
+                        "error.message" => err.to_string(),
+                    )
+                );
+                err
+            })
             .and_then(|modified_vulns| {
                 if let Some(mut modified_vulns) = modified_vulns {
                     for (k, v) in modified_vulns.drain() {
@@ -280,14 +290,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         err
                     })?;
                     let app_name = report.application_name.to_string();
-                    let records = parse_tool_report(&report, &vulns, safety_cve_map.as_ref().unwrap()).map_err(|err| {
-                        error!(error_logger, "Error parsing tool output in ToolReport";
-                            o!(
-                                "error.message" => err.to_string(),
-                            )
-                        );
-                        err
-                    })?;
+                    let records =
+                        parse_tool_report(&report, &vulns, safety_cve_map.as_ref().unwrap())
+                            .map_err(|err| {
+                                error!(error_logger, "Error parsing tool output in ToolReport";
+                                    o!(
+                                        "error.message" => err.to_string(),
+                                    )
+                                );
+                                err
+                            })?;
                     for record in records.into_iter() {
                         let kafka_payload = FutureRecord::to("DependencyEvents")
                             .payload(&record)
@@ -317,13 +329,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-
 #[derive(Clone)]
 struct VulnData {
-    cvss : Cvss, 
-    advisory_str: ComprString, 
-    advisory_url: String 
-} 
+    cvss: Cvss,
+    advisory_str: ComprString,
+    advisory_url: String,
+}
 
 fn download_and_parse_vulns(
     index: String,
@@ -347,13 +358,13 @@ fn download_and_parse_vulns(
         .map_err(|err| {
             Box::new(err_msg(format!("Error downloading {}: {}", meta_filename, err)).compat())
         })
-    .and_then(|resp| {
-        resp.text().map_err(|err| {
-            Box::new(
-                err_msg(format!("Error reading body of {}: {}", meta_filename, err)).compat(),
-            )
-        })
-    })?;
+        .and_then(|resp| {
+            resp.text().map_err(|err| {
+                Box::new(
+                    err_msg(format!("Error reading body of {}: {}", meta_filename, err)).compat(),
+                )
+            })
+        })?;
 
     let last_mod_timestamp = META_LAST_MOD_RE
         .captures(&meta_resp_text)
@@ -361,21 +372,21 @@ fn download_and_parse_vulns(
         .ok_or_else(|| {
             Box::new(
                 err_msg(format!(
-                        "Error reading lastModifiedDate from {}",
-                        meta_filename
+                    "Error reading lastModifiedDate from {}",
+                    meta_filename
                 ))
                 .compat(),
             )
         })
-    .map(|capture| capture.as_str())?;
+        .map(|capture| capture.as_str())?;
 
-let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
-    .captures(&meta_resp_text)
-    .and_then(|captures| captures.get(1))
-    .ok_or_else(|| {
-        Box::new(err_msg(format!("Error reading size from {}", meta_filename)).compat())
-    })
-.map(|capture| capture.as_str())?;
+    let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
+        .captures(&meta_resp_text)
+        .and_then(|captures| captures.get(1))
+        .ok_or_else(|| {
+            Box::new(err_msg(format!("Error reading size from {}", meta_filename)).compat())
+        })
+        .map(|capture| capture.as_str())?;
 
     let compressed_size = META_COMPRESSED_GZ_SIZE_RE
         .captures(&meta_resp_text)
@@ -383,21 +394,21 @@ let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
         .ok_or_else(|| {
             Box::new(
                 err_msg(format!(
-                        "Error reading compressed size from {}",
-                        meta_filename
+                    "Error reading compressed size from {}",
+                    meta_filename
                 ))
                 .compat(),
             )
         })
-    .map(|capture| capture.as_str())?;
+        .map(|capture| capture.as_str())?;
 
-let hash = META_SHA256_RE
-    .captures(&meta_resp_text)
-    .and_then(|captures| captures.get(1))
-    .ok_or_else(|| {
-        Box::new(err_msg(format!("Error reading sha256 hash from {}", meta_filename)).compat())
-    })
-.map(|capture| capture.as_str())?;
+    let hash = META_SHA256_RE
+        .captures(&meta_resp_text)
+        .and_then(|captures| captures.get(1))
+        .ok_or_else(|| {
+            Box::new(err_msg(format!("Error reading sha256 hash from {}", meta_filename)).compat())
+        })
+        .map(|capture| capture.as_str())?;
 
     if last_updated_time.is_none()
         || last_updated_time
@@ -428,11 +439,11 @@ let hash = META_SHA256_RE
 
         if hash != computed_hash {
             return Err(Box::new(
-                    err_msg(format!(
-                            "Hash mismatch for {}, expected {}, got {}",
-                            data_filename, hash, computed_hash
-                    ))
-                    .compat(),
+                err_msg(format!(
+                    "Hash mismatch for {}, expected {}, got {}",
+                    data_filename, hash, computed_hash
+                ))
+                .compat(),
             ));
         }
 
@@ -469,38 +480,39 @@ let hash = META_SHA256_RE
                     Cvss::builder().with_version(CvssVersion::Unknown).build()
                 };
 
-
                 let adv_text = vuln_info
                     .get("cve")
                     .and_then(|cve| cve.get("description"))
                     .and_then(|desc| desc.get("description_data"))
-                    .and_then(|desc_data| desc_data.get("value")).unwrap().to_string();
+                    .and_then(|desc_data| desc_data.get("value"))
+                    .unwrap()
+                    .to_string();
 
-                let compr_adv_text = ComprString::new(&adv_text); 
+                let compr_adv_text = ComprString::new(&adv_text);
 
                 let adv_url = vuln_info
                     .get("cve")
                     .and_then(|cve| cve.get("reference"))
                     .and_then(|refer| refer.get("reference_data"))
-                    .and_then(|refer_data| refer_data.get("url")).unwrap().to_string();
-
+                    .and_then(|refer_data| refer_data.get("url"))
+                    .unwrap()
+                    .to_string();
 
                 (
                     vuln_info["cve"]["CVE_data_meta"]["ID"]
-                    .as_str()
-                    .unwrap()
-                    .to_string(),
-                    VulnData { 
-                        advisory_str: compr_adv_text, 
-                        advisory_url: adv_url, 
-                        cvss: cvss.unwrap()
-                }
-                ,
+                        .as_str()
+                        .unwrap()
+                        .to_string(),
+                    VulnData {
+                        advisory_str: compr_adv_text,
+                        advisory_url: adv_url,
+                        cvss: cvss.unwrap(),
+                    },
                 )
             })
-        .collect::<HashMap<_, _>>();
+            .collect::<HashMap<_, _>>();
 
-    return Ok(Some(cve_items));
+        return Ok(Some(cve_items));
     }
 
     Ok(None)
@@ -509,25 +521,25 @@ let hash = META_SHA256_RE
 fn parse_tool_report(
     report: &ToolReport,
     vulns: &HashMap<String, VulnData>,
-    safety_vuln_map: &HashMap<String, Option<String>>
+    safety_vuln_map: &HashMap<String, Option<String>>,
 ) -> Result<Vec<Vec<u8>>, Box<dyn Error>> {
     let events = if report.tool_name == "bundler-audit" {
         if report.output_format == "PlainText" {
             parse_bundler_audit_plaintext(&report, &vulns)
         } else {
             Err(Box::new(
-                    err_msg(format!(
-                            "Unknown output format for Bundler-audit in ToolReport: {:?}",
-                            report
-                    ))
-                    .compat(),
+                err_msg(format!(
+                    "Unknown output format for Bundler-audit in ToolReport: {:?}",
+                    report
+                ))
+                .compat(),
             )
-                .into())
+            .into())
         }
-    } else if report.tool_name == "safety" { 
+    } else if report.tool_name == "safety" {
         if report.output_format == "JSON" {
             parse_safety_json(&report, vulns, safety_vuln_map)
-        } else if report.output_format == "PlainText" { 
+        } else if report.output_format == "PlainText" {
             Err(Box::new(
                     err_msg(format!(
                             "PlainText output not supported for safety; re-run safety with --json option in ToolReport: {:?}",
@@ -538,13 +550,13 @@ fn parse_tool_report(
                 .into())
         } else {
             Err(Box::new(
-                    err_msg(format!(
-                            "Unknown output format for safety in ToolReport: {:?}",
-                            report
-                    ))
-                    .compat(),
+                err_msg(format!(
+                    "Unknown output format for safety in ToolReport: {:?}",
+                    report
+                ))
+                .compat(),
             )
-                .into())
+            .into())
         }
     } else {
         Err(Box::new(err_msg(format!("Unknown tool in ToolReport: {:?}", report)).compat()).into())
@@ -580,11 +592,11 @@ fn parse_bundler_audit_plaintext(
             .collect::<HashMap<_, _>>();
         let advisory_id = AdvisoryId::try_from(
             fields
-            .get("Advisory")
-            .cloned()
-            .or_else(|| Some("".to_string()))
-            .unwrap()
-            .to_owned(),
+                .get("Advisory")
+                .cloned()
+                .or_else(|| Some("".to_string()))
+                .unwrap()
+                .to_owned(),
         )?;
 
         let default_cvss = Cvss::builder()
@@ -592,7 +604,9 @@ fn parse_bundler_audit_plaintext(
             .build()
             .unwrap();
 
-        let cvss = vulns.get(&advisory_id.to_string()).map_or(&default_cvss, |v| &v.cvss);
+        let cvss = vulns
+            .get(&advisory_id.to_string())
+            .map_or(&default_cvss, |v| &v.cvss);
 
         let mut event = DependencyEvent {
             event_version: EventVersion::try_from("1".to_string())?,
@@ -604,36 +618,36 @@ fn parse_bundler_audit_plaintext(
             timestamp: Timestamp::try_from(report.end_time.to_string())?,
             affected_package: AffectedPackage::try_from(
                 fields
-                .get("Name")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+                    .get("Name")
+                    .cloned()
+                    .or_else(|| Some("".to_string()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             installed_version: InstalledVersion::try_from(
                 fields
-                .get("Version")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+                    .get("Version")
+                    .cloned()
+                    .or_else(|| Some("".to_string()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             advisory_url: AdvisoryUrl::try_from(
                 fields
-                .get("URL")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+                    .get("URL")
+                    .cloned()
+                    .or_else(|| Some("".to_string()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             advisory_id,
             advisory_description: AdvisoryDescription::try_from(
                 fields
-                .get("Title")
-                .cloned()
-                .or_else(|| Some("".to_owned()))
-                .unwrap()
-                .to_owned(),
+                    .get("Title")
+                    .cloned()
+                    .or_else(|| Some("".to_owned()))
+                    .unwrap()
+                    .to_owned(),
             )?,
             cvss: cvss.clone(),
             suppressed: false,
@@ -654,115 +668,131 @@ struct PythonSafety {
     affected_package: String,
     affected_versions: String,
     installed_version: String,
-    advisory_description: String, 
-    advisory_id: String
+    advisory_description: String,
+    advisory_id: String,
 }
 
 #[derive(Deserialize, Debug)]
-struct MetaInfo { 
+struct MetaInfo {
     advisory: String,
-    timestamp: Value
+    timestamp: Value,
 }
 
 #[derive(Deserialize, Debug)]
-struct SafetyPackageVulnInfo{ 
+struct SafetyPackageVulnInfo {
     advisory: String,
     cve: Value,
     id: String,
     specs: Vec<String>,
     v: String,
-} 
+}
 
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]
-enum SafetyJsonData{
-    Vuln(Vec<SafetyPackageVulnInfo>), 
-        Meta(MetaInfo),
+enum SafetyJsonData {
+    Vuln(Vec<SafetyPackageVulnInfo>),
+    Meta(MetaInfo),
 }
-
 
 fn download_and_parse_python_safety_vulns(
     server_name: String,
-    etag: &mut Option<String>, 
-    client: &Client
-) -> Result<Option<HashMap<String, Option<String>>>, Box<dyn Error>>  {
-    let safety_json_db_url = &server_name.to_string(); 
+    etag: &mut Option<String>,
+    client: &Client,
+) -> Result<Option<HashMap<String, Option<String>>>, Box<dyn Error>> {
+    let safety_json_db_url = &server_name.to_string();
     let head_resp = client.head(safety_json_db_url).send()?;
     if head_resp.status().is_success() {
         if let Some(etag_new) = head_resp.headers().get(ETAG) {
-            // If the etag passed in is none or different to the one we just got, then download below.... 
-            match etag { 
-                Some(etag_old) => 
-                    if *etag_old == etag_new.to_str().unwrap() { 
-                        return Ok(None); 
-                    } else  { 
+            // If the etag passed in is none or different to the one we just got, then download below....
+            match etag {
+                Some(etag_old) => {
+                    if *etag_old == etag_new.to_str().unwrap() {
+                        return Ok(None);
+                    } else {
                         *etag = Some(etag_new.to_str().unwrap().to_owned());
-                    } 
-                None => 
-                    *etag = Some(etag_new.to_str().unwrap().to_owned()),
-            } 
+                    }
+                }
+                None => *etag = Some(etag_new.to_str().unwrap().to_owned()),
+            }
         }
     } else {
-        return Err(Box::new(err_msg(format!("Unable to grab head from python safety database: ({})",head_resp.status())).compat()).into())
-    } 
+        return Err(Box::new(
+            err_msg(format!(
+                "Unable to grab head from python safety database: ({})",
+                head_resp.status()
+            ))
+            .compat(),
+        )
+        .into());
+    }
 
-    let meta_resp_text = reqwest::blocking::get(safety_json_db_url)?
-        .text()?;
-    let python_safety_vuln_info_json: HashMap<String,SafetyJsonData> = serde_json::from_str(meta_resp_text.as_ref())?; 
-    let cve_items = python_safety_vuln_info_json.values()
-        .filter(|ref _s| match _s {SafetyJsonData::Vuln(_s) => true, _ => false })
-        .map(|s|  {
-            match s {
-                SafetyJsonData::Vuln(s) => s.iter(), 
-                _ => unreachable!()
-            }
+    let meta_resp_text = reqwest::blocking::get(safety_json_db_url)?.text()?;
+    let python_safety_vuln_info_json: HashMap<String, SafetyJsonData> =
+        serde_json::from_str(meta_resp_text.as_ref())?;
+    let cve_items = python_safety_vuln_info_json
+        .values()
+        .filter(|ref _s| match _s {
+            SafetyJsonData::Vuln(_s) => true,
+            _ => false,
         })
-    .collect::<Vec<_>>()
-        .into_iter().flatten().collect::<Vec<_>>()
+        .map(|s| match s {
+            SafetyJsonData::Vuln(s) => s.iter(),
+            _ => unreachable!(),
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
         .iter()
-        .map(|p| {
-            match &p.cve {
-                Value::String(s) => (p.id.to_owned(), Some(s.to_owned())),
-                _ => (p.id.to_owned(), None)
-            }
+        .map(|p| match &p.cve {
+            Value::String(s) => (p.id.to_owned(), Some(s.to_owned())),
+            _ => (p.id.to_owned(), None),
         })
-    .collect::<HashMap<_, _>>();
+        .collect::<HashMap<_, _>>();
     Ok(Some(cve_items))
 }
-
 
 fn parse_safety_json(
     report: &ToolReport,
     vulns: &HashMap<String, VulnData>,
-    safety_vulns: &HashMap<String, Option<String>>
+    safety_vulns: &HashMap<String, Option<String>>,
 ) -> Result<Vec<DependencyEvent>, Box<dyn Error>> {
     let mut events = Vec::new();
     let python_dep_vulns: Vec<PythonSafety> = serde_json::from_str(report.tool_output.as_ref())?;
     for vuln in python_dep_vulns.iter() {
-        let advisory_id = AdvisoryId::try_from(
-            vuln.advisory_id
-            .to_owned(),
-        )?;
+        let advisory_id = AdvisoryId::try_from(vuln.advisory_id.to_owned())?;
 
         let default_cvss = Cvss::builder()
             .with_version(CvssVersion::Unknown)
             .build()
             .unwrap();
 
-        let mut advisory_str = vuln.advisory_description.to_string(); 
-        let mut advisory_url = "https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json".to_string(); 
-        let mut cvss = &default_cvss; 
+        let mut advisory_str = vuln.advisory_description.to_string();
+        let mut advisory_url =
+            "https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json".to_string();
+        let mut cvss = &default_cvss;
 
-        match safety_vulns.get(&format!("pyup.io-{}", advisory_id.to_string())).unwrap() {
-            Some(s) => { 
-                let cve_vec = s.split(',').collect::<Vec<&str>>(); 
-                for cve_str in cve_vec { 
+        match safety_vulns
+            .get(&format!("pyup.io-{}", advisory_id.to_string()))
+            .unwrap()
+        {
+            Some(s) => {
+                let cve_vec = s.split(',').collect::<Vec<&str>>();
+                for cve_str in cve_vec {
                     cvss = vulns.get(cve_str).map_or(&default_cvss, |v| &v.cvss);
-                    advisory_str = vulns.get(cve_str).map_or(vuln.advisory_description.to_string(), |v| v.advisory_str.to_string());
-                    advisory_url = vulns.get(cve_str).map_or("https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json".to_string(), |v| v.advisory_url.to_string());
+                    advisory_str = vulns
+                        .get(cve_str)
+                        .map_or(vuln.advisory_description.to_string(), |v| {
+                            v.advisory_str.to_string()
+                        });
+                    advisory_url = vulns.get(cve_str).map_or(
+                        "https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json"
+                            .to_string(),
+                        |v| v.advisory_url.to_string(),
+                    );
                 }
-            },
-            _ => ()
+            }
+            _ => (),
         };
         let mut event = DependencyEvent {
             event_version: EventVersion::try_from("1".to_string())?,
@@ -772,31 +802,21 @@ fn parse_safety_json(
             git_branch: report.git_branch.clone(),
             git_commit_hash: report.git_commit_hash.clone(),
             timestamp: Timestamp::try_from(report.end_time.to_string())?,
-            affected_package: AffectedPackage::try_from(
-                vuln.affected_package
-                .to_owned(),
-            )?,
-            installed_version: InstalledVersion::try_from(
-                vuln.installed_version
-                .to_owned(),
-            )?,
-            advisory_url: AdvisoryUrl::try_from(
-                advisory_url,
-            )?,
+            affected_package: AffectedPackage::try_from(vuln.affected_package.to_owned())?,
+            installed_version: InstalledVersion::try_from(vuln.installed_version.to_owned())?,
+            advisory_url: AdvisoryUrl::try_from(advisory_url)?,
             advisory_id: advisory_id.clone(),
-            advisory_description: AdvisoryDescription::try_from(
-                advisory_str,
-            )?,
+            advisory_description: AdvisoryDescription::try_from(advisory_str)?,
             cvss: cvss.clone(),
             suppressed: false,
         };
 
-         let issue_hash = IssueHash::try_from(hex::encode(event.hash()))?;
+        let issue_hash = IssueHash::try_from(hex::encode(event.hash()))?;
 
-         event.suppressed =
-             should_issue_be_suppressed(&issue_hash, &report.suppressed_issues, &Utc::now());
+        event.suppressed =
+            should_issue_be_suppressed(&issue_hash, &report.suppressed_issues, &Utc::now());
 
-         events.push(event);
+        events.push(event);
     }
     Ok(events)
 }
@@ -835,7 +855,7 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
@@ -849,15 +869,15 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![SuppressedIssue {
             issue_hash: IssueHash::try_from(
-                            "a441b688fb60942c701fbcee0f30c66c0f7b22da7f0b4c51488488d2a2b64197".to_owned(),
-                        )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                "a441b688fb60942c701fbcee0f30c66c0f7b22da7f0b4c51488488d2a2b64197".to_owned(),
+            )
+            .unwrap(),
+            expiry_date: ExpiryDate::from(None),
+            suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+            suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
         }];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
@@ -871,26 +891,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 20).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 20).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "46a9d5bde718bf366178313019f04a753bad00685d38e3ec81c8628f35dfcb1b".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "46a9d5bde718bf366178313019f04a753bad00685d38e3ec81c8628f35dfcb1b".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -906,26 +926,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(0, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(0, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "9cf8847d2992e7219e659cdde1969e0d567ebab39a7aba13b36f9916fa26f6ca".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "9cf8847d2992e7219e659cdde1969e0d567ebab39a7aba13b36f9916fa26f6ca".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -941,26 +961,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 18).and_hms(10, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 18).and_hms(10, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "b100dabbadeedabbad1eadabbadeedabbad1edabbadeedabbad1eadabbadeeda".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "b100dabbadeedabbad1eadabbadeedabbad1edabbadeedabbad1eadabbadeeda".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -976,26 +996,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "a41f58ced5996b018dfbd697c1b16675f0cf864a3475d237cdd3f4d8c7160fdb".to_owned(),
-                            )
-                    .unwrap(),
-                    expiry_date: ExpiryDate::from(None),
-                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    "a41f58ced5996b018dfbd697c1b16675f0cf864a3475d237cdd3f4d8c7160fdb".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -1011,29 +1031,29 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 19).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 19).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
-            ];
+        ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
             true,
@@ -1047,29 +1067,29 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-            .unwrap();
+        .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                            )
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
+                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
                     .unwrap(),
-                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
-                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
-                        .unwrap(),
-                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
-            ];
+        ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
             true,
@@ -1078,31 +1098,41 @@ mod tests {
     }
 
     #[test]
-    fn download_safety_vuln_db_error_status() { 
+    fn download_safety_vuln_db_error_status() {
         let mut etag = None;
         let server = MockServer::start();
-        let mock = server.mock(|when,then| { 
+        let mock = server.mock(|when, then| {
             when.any_request();
             then.status(502);
         });
         let client = Client::new();
-        assert!(download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client).is_err(),"HTTP error status not handled correctly");
+        assert!(
+            download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client)
+                .is_err(),
+            "HTTP error status not handled correctly"
+        );
         mock.assert_hits(1);
     }
 
     #[test]
-    fn download_safety_vuln_db_etag_none() { 
+    fn download_safety_vuln_db_etag_none() {
         let mut etag = None;
         let server = MockServer::start();
-        let mock = server.mock(|when,then| { 
+        let mock = server.mock(|when, then| {
             when.any_request();
             then.status(200)
                 .header("Connection", "keep-alive")
                 .header("Content-Length", "348")
                 .header("Content-Type", "text/plain; charset=utf-8")
                 .header("Cache-Control", "max-age=300")
-                .header("Content-Security-Policy", "default-src \"none\"; style-src \"unsafe-inline\"; sandbox")
-                .header("ETag", "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"")
+                .header(
+                    "Content-Security-Policy",
+                    "default-src \"none\"; style-src \"unsafe-inline\"; sandbox",
+                )
+                .header(
+                    "ETag",
+                    "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
+                )
                 .header("Strict-Transport-Security", "max-age=31536000")
                 .header("X-Content-Type-Options", "nosniff")
                 .header("X-Frame-Options", "deny")
@@ -1118,66 +1148,87 @@ mod tests {
                 .header("X-Timer", "S1606997106.156669,VS0,VE1")
                 .header("Vary", "Authorization,Accept-Encoding, Accept-Encoding")
                 .header("Access-Control-Allow-Origin", "*")
-                .header("X-Fastly-Request-ID", "4d1a4685623b535c8417cc2dfab67794968e04a6")
+                .header(
+                    "X-Fastly-Request-ID",
+                    "4d1a4685623b535c8417cc2dfab67794968e04a6",
+                )
                 .header("Expires", "Thu, 03 Dec 2020 12:10:06 GMT")
                 .header("Source-Age", "129")
-                .json_body(
-                    json!({
-                        "$meta": {
-                            "advisory": "PyUp.io metadata",
-                            "timestamp": 1606802401
-                        },
-                        "acqusition": [
-                        {
-                            "advisory": "acqusition is a package affected by pytosquatting",
-                            "cve": null,
-                            "id": "pyup.io-34978",
-                            "specs": [
-                                    ">0",
-                                    "<0"
-                            ],
-                            "v": ">0,<0"
-                        }],
-                        "aegea": [
-                        {
-                            "advisory": "Aegea 2.2.7 avoids CVE-2018-1000805.",
-                            "cve": "CVE-2018-1000805",
-                            "id": "pyup.io-37611",
-                            "specs": [
-                                "<2.2.7"
-                            ],
-                            "v": "<2.2.7"
-                        }
-                        ]
+                .json_body(json!({
+                    "$meta": {
+                        "advisory": "PyUp.io metadata",
+                        "timestamp": 1606802401
+                    },
+                    "acqusition": [
+                    {
+                        "advisory": "acqusition is a package affected by pytosquatting",
+                        "cve": null,
+                        "id": "pyup.io-34978",
+                        "specs": [
+                            ">0",
+                            "<0"
+                        ],
+                        "v": ">0,<0"
+                    }],
+                    "aegea": [
+                    {
+                        "advisory": "Aegea 2.2.7 avoids CVE-2018-1000805.",
+                        "cve": "CVE-2018-1000805",
+                        "id": "pyup.io-37611",
+                        "specs": [
+                            "<2.2.7"
+                        ],
+                        "v": "<2.2.7"
+                    }
+                    ]
                 }));
         });
         let client = Client::new();
-        let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client); 
+        let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
         assert!(etag.is_some());
-        assert!(res.is_ok(), "Error result was produced when dealing with a None Etag");
-        let res_ok = res.unwrap(); 
-        assert!(res_ok.is_some(),"Python Safety vulns CVE hash not set when Etag is None");
+        assert!(
+            res.is_ok(),
+            "Error result was produced when dealing with a None Etag"
+        );
+        let res_ok = res.unwrap();
+        assert!(
+            res_ok.is_some(),
+            "Python Safety vulns CVE hash not set when Etag is None"
+        );
         let vhash = res_ok.unwrap();
-        assert!(vhash.len() > 0, "Incorrect number of elements in the Python safety map");
-        assert!(vhash.contains_key("pyup.io-37611"), "Python Safety map returned does not contain the correct key");
+        assert!(
+            vhash.len() > 0,
+            "Incorrect number of elements in the Python safety map"
+        );
+        assert!(
+            vhash.contains_key("pyup.io-37611"),
+            "Python Safety map returned does not contain the correct key"
+        );
         let value = vhash.get("pyup.io-37611").unwrap();
         assert_eq!(value.as_ref().unwrap(), "CVE-2018-1000805");
         mock.assert_hits(2);
     }
 
     #[test]
-    fn download_safety_vuln_db_etags_diff() { 
-        let mut etag = Some("3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f22".to_string());
+    fn download_safety_vuln_db_etags_diff() {
+        let mut etag =
+            Some("3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f22".to_string());
         let server = MockServer::start();
-        let mock = server.mock(|when,then| { 
+        let mock = server.mock(|when, then| {
             when.any_request();
             then.status(200)
                 .header("Connection", "keep-alive")
                 .header("Content-Length", "348")
                 .header("Content-Type", "text/plain; charset=utf-8")
                 .header("Cache-Control", "max-age=300")
-                .header("Content-Security-Policy", "default-src \"none\"; style-src \"unsafe-inline\"; sandbox")
-                .header("ETag", "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d4038a05ba4f26\"")
+                .header(
+                    "Content-Security-Policy",
+                    "default-src \"none\"; style-src \"unsafe-inline\"; sandbox",
+                )
+                .header(
+                    "ETag",
+                    "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d4038a05ba4f26\"",
+                )
                 .header("Strict-Transport-Security", "max-age=31536000")
                 .header("X-Content-Type-Options", "nosniff")
                 .header("X-Frame-Options", "deny")
@@ -1193,68 +1244,89 @@ mod tests {
                 .header("X-Timer", "S1606997106.156669,VS0,VE1")
                 .header("Vary", "Authorization,Accept-Encoding, Accept-Encoding")
                 .header("Access-Control-Allow-Origin", "*")
-                .header("X-Fastly-Request-ID", "4d1a4685623b535c8417cc2dfab67794968e04a6")
+                .header(
+                    "X-Fastly-Request-ID",
+                    "4d1a4685623b535c8417cc2dfab67794968e04a6",
+                )
                 .header("Expires", "Thu, 03 Dec 2020 12:10:06 GMT")
                 .header("Source-Age", "129")
-                .json_body(
-                    json!({
-                        "$meta": {
-                            "advisory": "PyUp.io metadata",
-                            "timestamp": 1606802401
-                        },
-                        "acqusition": [
-                        {
-                            "advisory": "acqusition is a package affected by pytosquatting",
-                            "cve": null,
-                            "id": "pyup.io-34978",
-                            "specs": [
-                                    ">0",
-                                    "<0"
-                            ],
-                            "v": ">0,<0"
-                        }],
-                        "aegea": [
-                        {
-                            "advisory": "Aegea 2.2.7 avoids CVE-2018-1000805.",
-                            "cve": "CVE-2018-1000805",
-                            "id": "pyup.io-37611",
-                            "specs": [
-                                "<2.2.7"
-                            ],
-                            "v": "<2.2.7"
-                        }
-                        ]
+                .json_body(json!({
+                    "$meta": {
+                        "advisory": "PyUp.io metadata",
+                        "timestamp": 1606802401
+                    },
+                    "acqusition": [
+                    {
+                        "advisory": "acqusition is a package affected by pytosquatting",
+                        "cve": null,
+                        "id": "pyup.io-34978",
+                        "specs": [
+                            ">0",
+                            "<0"
+                        ],
+                        "v": ">0,<0"
+                    }],
+                    "aegea": [
+                    {
+                        "advisory": "Aegea 2.2.7 avoids CVE-2018-1000805.",
+                        "cve": "CVE-2018-1000805",
+                        "id": "pyup.io-37611",
+                        "specs": [
+                            "<2.2.7"
+                        ],
+                        "v": "<2.2.7"
+                    }
+                    ]
                 }));
         });
         let client = Client::new();
         let old_etag = etag.clone();
-        let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client); 
+        let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
         assert!(etag.is_some());
         assert!(old_etag != etag, "Etags cannot be matching");
-        assert!(res.is_ok(), "Error result was produced when dealing with matching Etags");
+        assert!(
+            res.is_ok(),
+            "Error result was produced when dealing with matching Etags"
+        );
         let res_ok = res.unwrap();
-        assert!(res_ok.is_some(),"Python Safety vulns CVE hash not set when Etags are matching");
+        assert!(
+            res_ok.is_some(),
+            "Python Safety vulns CVE hash not set when Etags are matching"
+        );
         let vhash = res_ok.unwrap();
-        assert!(vhash.len() > 0, "Incorrect number of elements in the Python safety map");
-        assert!(vhash.contains_key("pyup.io-37611"), "Python Safety map returned does not contain the correct key");
+        assert!(
+            vhash.len() > 0,
+            "Incorrect number of elements in the Python safety map"
+        );
+        assert!(
+            vhash.contains_key("pyup.io-37611"),
+            "Python Safety map returned does not contain the correct key"
+        );
         let value = vhash.get("pyup.io-37611").unwrap();
         assert_eq!(value.as_ref().unwrap(), "CVE-2018-1000805");
         mock.assert_hits(2);
     }
-    
+
     #[test]
-    fn download_safety_vuln_db_etags_matching() { 
-        let mut etag = Some("3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26".to_string());
+    fn download_safety_vuln_db_etags_matching() {
+        let mut etag =
+            Some("3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26".to_string());
         let server = MockServer::start();
-        let mock = server.mock(|when,then| { 
+        let mock = server.mock(|when, then| {
             when.any_request();
             then.status(200)
                 .header("Connection", "keep-alive")
                 .header("Content-Length", "348")
                 .header("Content-Type", "text/plain; charset=utf-8")
                 .header("Cache-Control", "max-age=300")
-                .header("Content-Security-Policy", "default-src \"none\"; style-src \"unsafe-inline\"; sandbox")
-                .header("ETag", "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"")
+                .header(
+                    "Content-Security-Policy",
+                    "default-src \"none\"; style-src \"unsafe-inline\"; sandbox",
+                )
+                .header(
+                    "ETag",
+                    "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
+                )
                 .header("Strict-Transport-Security", "max-age=31536000")
                 .header("X-Content-Type-Options", "nosniff")
                 .header("X-Frame-Options", "deny")
@@ -1270,63 +1342,76 @@ mod tests {
                 .header("X-Timer", "S1606997106.156669,VS0,VE1")
                 .header("Vary", "Authorization,Accept-Encoding, Accept-Encoding")
                 .header("Access-Control-Allow-Origin", "*")
-                .header("X-Fastly-Request-ID", "4d1a4685623b535c8417cc2dfab67794968e04a6")
+                .header(
+                    "X-Fastly-Request-ID",
+                    "4d1a4685623b535c8417cc2dfab67794968e04a6",
+                )
                 .header("Expires", "Thu, 03 Dec 2020 12:10:06 GMT")
                 .header("Source-Age", "129")
-                .json_body(
-                    json!({
-                        "$meta": {
-                            "advisory": "PyUp.io metadata",
-                            "timestamp": 1606802401
-                        },
-                        "acqusition": [
-                        {
-                            "advisory": "acqusition is a package affected by pytosquatting",
-                            "cve": null,
-                            "id": "pyup.io-34978",
-                            "specs": [
-                                    ">0",
-                                    "<0"
-                            ],
-                            "v": ">0,<0"
-                        }],
-                        "aegea": [
-                        {
-                            "advisory": "Aegea 2.2.7 avoids CVE-2018-1000805.",
-                            "cve": "CVE-2018-1000805",
-                            "id": "pyup.io-37611",
-                            "specs": [
-                                "<2.2.7"
-                            ],
-                            "v": "<2.2.7"
-                        }
-                        ]
+                .json_body(json!({
+                    "$meta": {
+                        "advisory": "PyUp.io metadata",
+                        "timestamp": 1606802401
+                    },
+                    "acqusition": [
+                    {
+                        "advisory": "acqusition is a package affected by pytosquatting",
+                        "cve": null,
+                        "id": "pyup.io-34978",
+                        "specs": [
+                            ">0",
+                            "<0"
+                        ],
+                        "v": ">0,<0"
+                    }],
+                    "aegea": [
+                    {
+                        "advisory": "Aegea 2.2.7 avoids CVE-2018-1000805.",
+                        "cve": "CVE-2018-1000805",
+                        "id": "pyup.io-37611",
+                        "specs": [
+                            "<2.2.7"
+                        ],
+                        "v": "<2.2.7"
+                    }
+                    ]
                 }));
         });
         let client = Client::new();
         let old_etag = etag.clone();
-        let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client); 
+        let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
         assert!(old_etag == etag);
-        assert!(res.is_ok(), "Error result was produced when dealing with a matching Etags");
-        let res_ok = res.unwrap(); 
-        assert!(res_ok.is_none(),"Matching etags should produce a None result");
+        assert!(
+            res.is_ok(),
+            "Error result was produced when dealing with a matching Etags"
+        );
+        let res_ok = res.unwrap();
+        assert!(
+            res_ok.is_none(),
+            "Matching etags should produce a None result"
+        );
         mock.assert_hits(1);
     }
 
-
     #[test]
-    fn download_safety_vuln_db_etag_some() { 
+    fn download_safety_vuln_db_etag_some() {
         let mut etag = None;
         let server = MockServer::start();
-        let mock = server.mock(|when,then| { 
+        let mock = server.mock(|when, then| {
             when.any_request();
             then.status(200)
                 .header("Connection", "keep-alive")
                 .header("Content-Length", "348")
                 .header("Content-Type", "text/plain; charset=utf-8")
                 .header("Cache-Control", "max-age=300")
-                .header("Content-Security-Policy", "default-src \"none\"; style-src \"unsafe-inline\"; sandbox")
-                .header("ETag", "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"")
+                .header(
+                    "Content-Security-Policy",
+                    "default-src \"none\"; style-src \"unsafe-inline\"; sandbox",
+                )
+                .header(
+                    "ETag",
+                    "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
+                )
                 .header("Strict-Transport-Security", "max-age=31536000")
                 .header("X-Content-Type-Options", "nosniff")
                 .header("X-Frame-Options", "deny")
@@ -1342,66 +1427,71 @@ mod tests {
                 .header("X-Timer", "S1606997106.156669,VS0,VE1")
                 .header("Vary", "Authorization,Accept-Encoding, Accept-Encoding")
                 .header("Access-Control-Allow-Origin", "*")
-                .header("X-Fastly-Request-ID", "4d1a4685623b535c8417cc2dfab67794968e04a6")
+                .header(
+                    "X-Fastly-Request-ID",
+                    "4d1a4685623b535c8417cc2dfab67794968e04a6",
+                )
                 .header("Expires", "Thu, 03 Dec 2020 12:10:06 GMT")
                 .header("Source-Age", "129")
-                .json_body(
-                    json!({
-                        "$meta": {
-                            "advisory": "PyUp.io metadata",
-                            "timestamp": 1606802401
-                        },
-                        "acqusition": [
-                        {
-                            "advisory": "acqusition is a package affected by pytosquatting",
-                            "cve": null,
-                            "id": "pyup.io-34978",
-                            "specs": [
-                                    ">0",
-                                    "<0"
-                            ],
-                            "v": ">0,<0"
-                        }],
-                        "aegea": [
-                        {
-                            "advisory": "Aegea 2.2.7 avoids CVE-2018-1000805.",
-                            "cve": "CVE-2018-1000805",
-                            "id": "pyup.io-37611",
-                            "specs": [
-                                "<2.2.7"
-                            ],
-                            "v": "<2.2.7"
-                        }
-                        ]
+                .json_body(json!({
+                    "$meta": {
+                        "advisory": "PyUp.io metadata",
+                        "timestamp": 1606802401
+                    },
+                    "acqusition": [
+                    {
+                        "advisory": "acqusition is a package affected by pytosquatting",
+                        "cve": null,
+                        "id": "pyup.io-34978",
+                        "specs": [
+                            ">0",
+                            "<0"
+                        ],
+                        "v": ">0,<0"
+                    }],
+                    "aegea": [
+                    {
+                        "advisory": "Aegea 2.2.7 avoids CVE-2018-1000805.",
+                        "cve": "CVE-2018-1000805",
+                        "id": "pyup.io-37611",
+                        "specs": [
+                            "<2.2.7"
+                        ],
+                        "v": "<2.2.7"
+                    }
+                    ]
                 }));
         });
         let client = Client::new();
-        match download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client){ 
+        match download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client) {
             Err(e) => println!("Error: Unable to download safety vulns: {} \n", e),
-            Ok(Some(vulnshash)) => { 
+            Ok(Some(vulnshash)) => {
                 println!("Etag:{:?}", etag.clone());
-                for (key,val) in &vulnshash {
-                    match val { 
-                        Some(cve) => 
-                            println!("{} --> {}", key, cve), 
-                        None => () 
-                    } 
+                for (key, val) in &vulnshash {
+                    match val {
+                        Some(cve) => println!("{} --> {}", key, cve),
+                        None => (),
+                    }
                 }
-            }, 
-            Ok(None) => println!("Error: No vulnshash returned")
+            }
+            Ok(None) => println!("Error: No vulnshash returned"),
         }
         let old_etag = etag.clone();
         /* Download again to ensure that matching etags returns None */
-        let newvulns = download_and_parse_python_safety_vulns(server.url("/data"),&mut etag, &client).expect("Download safety vuln returned Error");
+        let newvulns =
+            download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client)
+                .expect("Download safety vuln returned Error");
         assert!(etag == old_etag, "Error: etags do not match");
-        assert!(newvulns.is_none(), "Error: Safety vulns downloaded despite matching etags");
+        assert!(
+            newvulns.is_none(),
+            "Error: Safety vulns downloaded despite matching etags"
+        );
         mock.assert_hits(3);
     }
 
-
     #[test]
-    fn serde_parse_safety(){
-        let serde_json_data= r#"
+    fn serde_parse_safety() {
+        let serde_json_data = r#"
         {
 
              "$meta": {
@@ -1434,15 +1524,15 @@ mod tests {
         }
         "#;
 
-        let python_safety_vuln_info_json: HashMap<String,SafetyJsonData> = serde_json::from_str(serde_json_data.as_ref()).unwrap();
-        for (k,_v) in python_safety_vuln_info_json { 
-            println! ("Keys = {}", k)
-        } 
-
+        let python_safety_vuln_info_json: HashMap<String, SafetyJsonData> =
+            serde_json::from_str(serde_json_data.as_ref()).unwrap();
+        for (k, _v) in python_safety_vuln_info_json {
+            println!("Keys = {}", k)
+        }
     }
 
     #[test]
-    fn parse_python_safety_vulns() { 
+    fn parse_python_safety_vulns() {
         let python_safety_vulns = r#"[
     [
         "rsa",
@@ -1459,47 +1549,63 @@ mod tests {
         "38100"
     ]]"#;
 
-    let compr_adv_text = ComprString::new("Some advsiory text");
+        let compr_adv_text = ComprString::new("Some advsiory text");
 
-    let safety_cve_map : HashMap<String, Option<String>> = [("pyup.io-38414".to_string(), Some("CVE-2020-13757".to_string()))].iter().cloned().collect(); 
+        let safety_cve_map: HashMap<String, Option<String>> = [(
+            "pyup.io-38414".to_string(),
+            Some("CVE-2020-13757".to_string()),
+        )]
+        .iter()
+        .cloned()
+        .collect();
 
-    let vulnshash: HashMap<String, VulnData> = 
-        [("CVE-2020-13757".to_string(), 
-            VulnData  {
-                advisory_str: compr_adv_text, 
-                advisory_url: "http://someurl.co.uk".to_string(), 
+        let vulnshash: HashMap<String, VulnData> = [(
+            "CVE-2020-13757".to_string(),
+            VulnData {
+                advisory_str: compr_adv_text,
+                advisory_url: "http://someurl.co.uk".to_string(),
                 cvss: Cvss::builder()
                     .with_version(CvssVersion::V2)
                     .with_score(Some(7.5))
-                    .build().unwrap()
-            }
-        )].iter().cloned().collect();
-    let test_report = ToolReport {
-        event_version: EventVersion::try_from("1".to_owned()).unwrap(),
-        event_id: EventID::try_from("95130bee-95ae-4dac-aecf-5650ff646ea1".to_owned()).unwrap(),
-        application_name: ApplicationName::try_from("Test application".to_owned()).unwrap(),
-        git_branch: GitBranch::try_from(Some("git".to_owned())).unwrap(),
-        git_commit_hash: GitCommitHash::try_from(
-            "e99f715d0fe787cd43de967b8a79b56960fed3e5".to_owned(),
-        )
+                    .build()
+                    .unwrap(),
+            },
+        )]
+        .iter()
+        .cloned()
+        .collect();
+        let test_report = ToolReport {
+            event_version: EventVersion::try_from("1".to_owned()).unwrap(),
+            event_id: EventID::try_from("95130bee-95ae-4dac-aecf-5650ff646ea1".to_owned()).unwrap(),
+            application_name: ApplicationName::try_from("Test application".to_owned()).unwrap(),
+            git_branch: GitBranch::try_from(Some("git".to_owned())).unwrap(),
+            git_commit_hash: GitCommitHash::try_from(
+                "e99f715d0fe787cd43de967b8a79b56960fed3e5".to_owned(),
+            )
             .unwrap(),
             tool_name: ToolName::try_from("safety".to_owned()).unwrap(),
             tool_output: ToolOutput::try_from(python_safety_vulns.to_owned()).unwrap(),
             output_format: OutputFormat::JSON,
             start_time: StartTime::from(DateTime::<Utc>::from(
-                    DateTime::parse_from_rfc3339("2019-09-13T19:35:38+00:00").unwrap(),
+                DateTime::parse_from_rfc3339("2019-09-13T19:35:38+00:00").unwrap(),
             )),
             end_time: EndTime::from(DateTime::<Utc>::from(
-                    DateTime::parse_from_rfc3339("2019-09-13T19:37:14+00:00").unwrap(),
+                DateTime::parse_from_rfc3339("2019-09-13T19:37:14+00:00").unwrap(),
             )),
             environment: Environment::Local,
             tool_version: ToolVersion::try_from(Some("1.0".to_owned())).unwrap(),
             suppressed_issues: vec![],
-    };
-    let events = parse_safety_json(&test_report, &vulnshash, &safety_cve_map); 
-    for event in &events.unwrap() { 
-        println!("affected package: {}, installed version: {}, cvss: {}, url: {},  advisory: {}\n", event.affected_package, event.installed_version, event.cvss, event.advisory_url, event.advisory_description)
-    } 
+        };
+        let events = parse_safety_json(&test_report, &vulnshash, &safety_cve_map);
+        for event in &events.unwrap() {
+            println!(
+                "affected package: {}, installed version: {}, cvss: {}, url: {},  advisory: {}\n",
+                event.affected_package,
+                event.installed_version,
+                event.cvss,
+                event.advisory_url,
+                event.advisory_description
+            )
+        }
     }
-
 }

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -48,7 +48,7 @@ use uuid::Uuid;
 
 const SERVICE_NAME: &str = "report-parser";
 const PYTHON_SAFETY_VULN_URL: &str =
-    "https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json";
+    "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -191,11 +191,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     })?;
 
     let mut etag = None;
-    let safety_json_db_url =
-        "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json"
-            .to_string();
     let mut safety_cve_map =
-        download_and_parse_python_safety_vulns(safety_json_db_url.clone(), &mut etag, &client)
+        download_and_parse_python_safety_vulns(PYTHON_SAFETY_VULN_URL.to_string(), &mut etag, &client)
             .map_err(|err| {
                 error!(error_logger, "Error downloading Python Safety Vulns";
                     o!(
@@ -215,7 +212,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .lt(&(Utc::now() - Duration::days(1)))
         {
             let new_safety_cve_map = download_and_parse_python_safety_vulns(
-                safety_json_db_url.clone(),
+                PYTHON_SAFETY_VULN_URL.to_string(),
                 &mut etag,
                 &client,
             )

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -480,7 +480,9 @@ fn download_and_parse_vulns(
                     .and_then(|cve| cve.get("description"))
                     .and_then(|desc| desc.get("description_data"));
 
-                let adv = desc_data_arr.filter(|x| x["value"]=="en").unwrap()[0]["value"].as_str().unwrap_or("");
+                let adv = desc_data_arr.filter(|x| x["value"] == "en").unwrap()[0]["value"]
+                    .as_str()
+                    .unwrap_or("");
 
                 let compr_adv_text = ComprString::new(&adv);
 

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -1131,7 +1131,7 @@ mod tests {
                 )
                 .header(
                     "ETag",
-                    "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
+                    "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
                 )
                 .header("Strict-Transport-Security", "max-age=31536000")
                 .header("X-Content-Type-Options", "nosniff")
@@ -1212,7 +1212,7 @@ mod tests {
     #[test]
     fn download_safety_vuln_db_etags_diff() {
         let mut etag =
-            Some("3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f22".to_string());
+            Some("\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f22\"".to_string());
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.any_request();
@@ -1227,7 +1227,7 @@ mod tests {
                 )
                 .header(
                     "ETag",
-                    "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d4038a05ba4f26\"",
+                    "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d4038a05ba4f26\"",
                 )
                 .header("Strict-Transport-Security", "max-age=31536000")
                 .header("X-Content-Type-Options", "nosniff")
@@ -1310,7 +1310,7 @@ mod tests {
     #[test]
     fn download_safety_vuln_db_etags_matching() {
         let mut etag =
-            Some("3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26".to_string());
+            Some("\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"".to_string());
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.any_request();
@@ -1325,7 +1325,7 @@ mod tests {
                 )
                 .header(
                     "ETag",
-                    "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
+                    "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
                 )
                 .header("Strict-Transport-Security", "max-age=31536000")
                 .header("X-Content-Type-Options", "nosniff")
@@ -1393,143 +1393,26 @@ mod tests {
         mock.assert_hits(1);
     }
 
-    #[test]
-    fn download_safety_vuln_db_etag_some() {
-        let mut etag = None;
-        let server = MockServer::start();
-        let mock = server.mock(|when, then| {
-            when.any_request();
-            then.status(200)
-                .header("Connection", "keep-alive")
-                .header("Content-Length", "348")
-                .header("Content-Type", "text/plain; charset=utf-8")
-                .header("Cache-Control", "max-age=300")
-                .header(
-                    "Content-Security-Policy",
-                    "default-src \"none\"; style-src \"unsafe-inline\"; sandbox",
-                )
-                .header(
-                    "ETag",
-                    "W/\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
-                )
-                .header("Strict-Transport-Security", "max-age=31536000")
-                .header("X-Content-Type-Options", "nosniff")
-                .header("X-Frame-Options", "deny")
-                .header("X-XSS-Protection", "1; mode=block")
-                .header("Via", "1.1 varnish (Varnish/6.0), 1.1 varnish")
-                .header("Content-Encoding", "gzip")
-                .header("X-GitHub-Request-Id", "2DD2:2A31:366058:393F4A:5FC8BA35")
-                .header("Accept-Ranges", "bytes")
-                .header("Date", "Thu, 03 Dec 2020 12:05:06 GMT")
-                .header("X-Served-By", "cache-lcy19250-LCY")
-                .header("X-Cache", "HFM, HIT")
-                .header("X-Cache-Hits", "0, 1")
-                .header("X-Timer", "S1606997106.156669,VS0,VE1")
-                .header("Vary", "Authorization,Accept-Encoding, Accept-Encoding")
-                .header("Access-Control-Allow-Origin", "*")
-                .header(
-                    "X-Fastly-Request-ID",
-                    "4d1a4685623b535c8417cc2dfab67794968e04a6",
-                )
-                .header("Expires", "Thu, 03 Dec 2020 12:10:06 GMT")
-                .header("Source-Age", "129")
-                .json_body(json!({
-                    "$meta": {
-                        "advisory": "PyUp.io metadata",
-                        "timestamp": 1606802401
-                    },
-                    "acqusition": [
-                    {
-                        "advisory": "acqusition is a package affected by pytosquatting",
-                        "cve": null,
-                        "id": "pyup.io-34978",
-                        "specs": [
-                            ">0",
-                            "<0"
-                        ],
-                        "v": ">0,<0"
-                    }],
-                    "aegea": [
-                    {
-                        "advisory": "Aegea 2.2.7 avoids CVE-2018-1000805.",
-                        "cve": "CVE-2018-1000805",
-                        "id": "pyup.io-37611",
-                        "specs": [
-                            "<2.2.7"
-                        ],
-                        "v": "<2.2.7"
-                    }
-                    ]
-                }));
-        });
+    /*
+     #[test]
+    fn download_safety_vuln_db() { 
         let client = Client::new();
-        match download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client) {
-            Err(e) => println!("Error: Unable to download safety vulns: {} \n", e),
-            Ok(Some(vulnshash)) => {
-                println!("Etag:{:?}", etag.clone());
-                for (key, val) in &vulnshash {
-                    match val {
-                        Some(cve) => println!("{} --> {}", key, cve),
-                        None => (),
-                    }
+        let mut etag = None;
+        match download_and_parse_python_safety_vulns("https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json".to_string(), &mut etag, &client){ 
+            Err(e) => println!("Error downloading safety vulns: {} \n", e),
+            Ok(Some(vulnshash)) => { 
+                for (key,val) in &vulnshash {
+                    match val { 
+                        Some(cve) => 
+                            println!("{} --> {}", key,cve), 
+                        None => () 
+                    } 
                 }
-            }
-            Ok(None) => println!("Error: No vulnshash returned"),
+            },
+            Ok(None) => ()
         }
-        let old_etag = etag.clone();
-        /* Download again to ensure that matching etags returns None */
-        let newvulns =
-            download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client)
-                .expect("Download safety vuln returned Error");
-        assert!(etag == old_etag, "Error: etags do not match");
-        assert!(
-            newvulns.is_none(),
-            "Error: Safety vulns downloaded despite matching etags"
-        );
-        mock.assert_hits(3);
-    }
+    } */
 
-    #[test]
-    fn serde_parse_safety() {
-        let serde_json_data = r#"
-        {
-
-             "$meta": {
-                "advisory": "PyUp.io metadata",
-                "timestamp": 1601532001
-             }, 
-             "acqusition": [
-                {
-                    "advisory": "acqusition is a package affected by pytosquatting: http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/",
-                    "cve": null,
-                    "id": "pyup.io-34978",
-                    "specs": [
-                        ">0",
-                        "<0"
-                    ],
-                    "v": ">0,<0"
-                }
-            ], 
-            "aegea": [
-                {
-                    "advisory": "Aegea 2.2.7 avoids CVE-2018-1000805.",
-                    "cve": "CVE-2018-1000805",
-                    "id": "pyup.io-37611",
-                    "specs": [
-                        "<2.2.7"
-                    ],
-                    "v": "<2.2.7"
-                }
-            ]
-        }
-        "#;
-
-        let python_safety_vuln_info_json: HashMap<String, SafetyJsonData> =
-            serde_json::from_str(serde_json_data.as_ref()).unwrap();
-        for (k, _v) in python_safety_vuln_info_json {
-            println!("Keys = {}", k)
-        }
-    }
 
     #[test]
     fn parse_python_safety_vulns() {

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -475,14 +475,20 @@ fn download_and_parse_vulns(
                     Cvss::builder().with_version(CvssVersion::Unknown).build()
                 };
 
-                let desc_data_arr = vuln_info
+                let desc_data = vuln_info
                     .get("cve")
                     .and_then(|cve| cve.get("description"))
-                    .and_then(|desc| desc.get("description_data"));
+                    .and_then(|desc| desc.get("description_data"))
+                    .unwrap()
+                    .as_array();
 
-                let adv = desc_data_arr.filter(|x| x["value"] == "en").unwrap()[0]["value"]
-                    .as_str()
-                    .unwrap_or("");
+                let adv = desc_data
+                    .unwrap()
+                    .iter()
+                    .filter(|x| x["lang"].as_str().unwrap() == "en")
+                    .next()
+                    .and_then(|y| Some(y["value"].as_str().unwrap().to_string()))
+                    .unwrap_or("".to_string());
 
                 let compr_adv_text = ComprString::new(&adv);
 

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -191,16 +191,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
     })?;
 
     let mut etag = None;
-    let mut safety_cve_map =
-        download_and_parse_python_safety_vulns(PYTHON_SAFETY_VULN_URL.to_string(), &mut etag, &client)
-            .map_err(|err| {
-                error!(error_logger, "Error downloading Python Safety Vulns";
-                    o!(
-                        "error.message" => err.to_string(),
-                    )
-                );
-                err
-            })?;
+    let mut safety_cve_map = download_and_parse_python_safety_vulns(
+        &PYTHON_SAFETY_VULN_URL,
+        &mut etag,
+        &client,
+    )
+    .map_err(|err| {
+        error!(error_logger, "Error downloading Python Safety Vulns";
+            o!(
+                "error.message" => err.to_string(),
+            )
+        );
+        err
+    })?;
 
     last_updated_time = Some(Utc::now());
 
@@ -212,7 +215,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .lt(&(Utc::now() - Duration::days(1)))
         {
             let new_safety_cve_map = download_and_parse_python_safety_vulns(
-                PYTHON_SAFETY_VULN_URL.to_string(),
+                &PYTHON_SAFETY_VULN_URL,
                 &mut etag,
                 &client,
             )
@@ -686,7 +689,7 @@ enum SafetyJsonData {
 }
 
 fn download_and_parse_python_safety_vulns(
-    server_name: String,
+    server_name: &str,
     etag: &mut Option<String>,
     client: &Client,
 ) -> Result<Option<HashMap<String, Option<String>>>, Box<dyn Error>> {
@@ -1104,7 +1107,7 @@ mod tests {
         });
         let client = Client::new();
         assert!(
-            download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client)
+            download_and_parse_python_safety_vulns(&server.url("/data"), &mut etag, &client)
                 .is_err(),
             "HTTP error status not handled correctly"
         );
@@ -1159,7 +1162,7 @@ mod tests {
                 }));
         });
         let client = Client::new();
-        let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
+        let res = download_and_parse_python_safety_vulns(&server.url("/data"), &mut etag, &client);
         assert!(etag.is_some());
         assert!(
             etag.unwrap() == "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\""
@@ -1235,7 +1238,7 @@ mod tests {
         });
         let client = Client::new();
         let old_etag = etag.clone();
-        let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
+        let res = download_and_parse_python_safety_vulns(&server.url("/data"), &mut etag, &client);
         assert!(etag.is_some());
         assert!(
             old_etag.unwrap() != etag.clone().unwrap(),
@@ -1315,7 +1318,7 @@ mod tests {
         });
         let client = Client::new();
         let old_etag = etag.clone();
-        let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
+        let res = download_and_parse_python_safety_vulns(&server.url("/data"), &mut etag, &client);
         assert!(old_etag.unwrap() == etag.unwrap());
         assert!(
             res.is_ok(),

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -53,6 +53,7 @@ use uuid::Uuid;
 use httpmock::MockServer;
 
 const SERVICE_NAME: &str = "report-parser";
+const PYTHON_SAFETY_VULN_URL: &str ="https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -82,7 +83,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 Uuid::new_v4().to_hyphenated().to_string()
             }),
         ),
-    );
+        );
 
     let error_logger = root_logger.new(o!("event.type" => EventType(vec!("error".to_string()))));
 
@@ -125,7 +126,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let base_url = Url::parse(
         &env::var("NVD_BASE_URL")
-            .unwrap_or_else(|_| "https://nvd.nist.gov/feeds/json/cve/1.1/".to_string()),
+        .unwrap_or_else(|_| "https://nvd.nist.gov/feeds/json/cve/1.1/".to_string()),
     )?;
     let mut last_updated_time = None;
     let client_builder = Client::builder();
@@ -145,23 +146,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 );
                 err
             })
-            .and_then(|parsed_vulns| {
-                parsed_vulns
-                    .into_iter()
-                    .fold(&mut vulns, |acc, mut values| {
-                        for (k, v) in values.drain() {
-                            acc.insert(k, v);
-                        }
-                        acc
-                    });
-                info!(root_logger, "Successfully got vulns for {}", year;
-                    o!(
-                        "event.type" => EventType(vec!("info".to_string())),
-                    )
-                );
-                Ok(())
-            })?;
-    }
+        .and_then(|parsed_vulns| {
+            parsed_vulns
+                .into_iter()
+                .fold(&mut vulns, |acc, mut values| {
+                    for (k, v) in values.drain() {
+                        acc.insert(k, v);
+                    }
+                    acc
+                });
+            info!(root_logger, "Successfully got vulns for {}", year;
+                o!(
+                    "event.type" => EventType(vec!("info".to_string())),
+                )
+            );
+            Ok(())
+        })?;
+            }
 
     download_and_parse_vulns(
         "modified".to_string(),
@@ -169,14 +170,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &base_url,
         &client,
     )
-    .map_err(|err| {
-        error!(error_logger, "Error downloading modified vulns info";
-            o!(
-                "error.message" => err.to_string(),
-            )
-        );
-        err
-    })
+        .map_err(|err| {
+            error!(error_logger, "Error downloading modified vulns info";
+                o!(
+                    "error.message" => err.to_string(),
+                )
+            );
+            err
+        })
     .and_then(|modified_vulns| {
         modified_vulns
             .into_iter()
@@ -197,17 +198,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut etag = None;
     let safety_json_db_url =
         "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json"
-            .to_string();
+        .to_string();
     let mut safety_cve_map =
         download_and_parse_python_safety_vulns(safety_json_db_url.clone(), &mut etag, &client)
-            .map_err(|err| {
-                error!(error_logger, "Error downloading Python Safety Vulns";
-                    o!(
-                        "error.message" => err.to_string(),
-                    )
-                );
-                err
-            })?;
+        .map_err(|err| {
+            error!(error_logger, "Error downloading Python Safety Vulns";
+                o!(
+                    "error.message" => err.to_string(),
+                )
+            );
+            err
+        })?;
 
     last_updated_time = Some(Utc::now());
 
@@ -216,21 +217,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
     loop {
         if last_updated_time
             .unwrap()
-            .lt(&(Utc::now() - Duration::days(1)))
+                .lt(&(Utc::now() - Duration::days(1)))
         {
             let new_safety_cve_map = download_and_parse_python_safety_vulns(
                 safety_json_db_url.clone(),
                 &mut etag,
                 &client,
             )
-            .map_err(|err| {
-                error!(error_logger, "Error downloading Python Safety Vulns";
-                    o!(
-                        "error.message" => err.to_string(),
-                    )
-                );
-                err
-            })?;
+                .map_err(|err| {
+                    error!(error_logger, "Error downloading Python Safety Vulns";
+                        o!(
+                            "error.message" => err.to_string(),
+                        )
+                    );
+                    err
+                })?;
             if new_safety_cve_map.is_some() {
                 safety_cve_map = new_safety_cve_map;
             }
@@ -238,7 +239,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         if last_updated_time
             .unwrap()
-            .lt(&(Utc::now() - Duration::hours(2)))
+                .lt(&(Utc::now() - Duration::hours(2)))
         {
             download_and_parse_vulns(
                 "modified".to_string(),
@@ -246,14 +247,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 &base_url,
                 &client,
             )
-            .map_err(|err| {
-                error!(error_logger, "Error updating vuln info";
-                    o!(
-                        "error.message" => err.to_string(),
-                    )
-                );
-                err
-            })
+                .map_err(|err| {
+                    error!(error_logger, "Error updating vuln info";
+                        o!(
+                            "error.message" => err.to_string(),
+                        )
+                    );
+                    err
+                })
             .and_then(|modified_vulns| {
                 if let Some(mut modified_vulns) = modified_vulns {
                     for (k, v) in modified_vulns.drain() {
@@ -292,14 +293,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     let app_name = report.application_name.to_string();
                     let records =
                         parse_tool_report(&report, &vulns, safety_cve_map.as_ref().unwrap())
-                            .map_err(|err| {
-                                error!(error_logger, "Error parsing tool output in ToolReport";
-                                    o!(
-                                        "error.message" => err.to_string(),
-                                    )
-                                );
-                                err
-                            })?;
+                        .map_err(|err| {
+                            error!(error_logger, "Error parsing tool output in ToolReport";
+                                o!(
+                                    "error.message" => err.to_string(),
+                                )
+                            );
+                            err
+                        })?;
                     for record in records.into_iter() {
                         let kafka_payload = FutureRecord::to("DependencyEvents")
                             .payload(&record)
@@ -358,13 +359,13 @@ fn download_and_parse_vulns(
         .map_err(|err| {
             Box::new(err_msg(format!("Error downloading {}: {}", meta_filename, err)).compat())
         })
-        .and_then(|resp| {
-            resp.text().map_err(|err| {
-                Box::new(
-                    err_msg(format!("Error reading body of {}: {}", meta_filename, err)).compat(),
-                )
-            })
-        })?;
+    .and_then(|resp| {
+        resp.text().map_err(|err| {
+            Box::new(
+                err_msg(format!("Error reading body of {}: {}", meta_filename, err)).compat(),
+            )
+        })
+    })?;
 
     let last_mod_timestamp = META_LAST_MOD_RE
         .captures(&meta_resp_text)
@@ -372,21 +373,21 @@ fn download_and_parse_vulns(
         .ok_or_else(|| {
             Box::new(
                 err_msg(format!(
-                    "Error reading lastModifiedDate from {}",
-                    meta_filename
+                        "Error reading lastModifiedDate from {}",
+                        meta_filename
                 ))
                 .compat(),
             )
         })
-        .map(|capture| capture.as_str())?;
+    .map(|capture| capture.as_str())?;
 
-    let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
-        .captures(&meta_resp_text)
-        .and_then(|captures| captures.get(1))
-        .ok_or_else(|| {
-            Box::new(err_msg(format!("Error reading size from {}", meta_filename)).compat())
-        })
-        .map(|capture| capture.as_str())?;
+let uncompressed_size = META_UNCOMPRESSED_SIZE_RE
+    .captures(&meta_resp_text)
+    .and_then(|captures| captures.get(1))
+    .ok_or_else(|| {
+        Box::new(err_msg(format!("Error reading size from {}", meta_filename)).compat())
+    })
+.map(|capture| capture.as_str())?;
 
     let compressed_size = META_COMPRESSED_GZ_SIZE_RE
         .captures(&meta_resp_text)
@@ -394,21 +395,21 @@ fn download_and_parse_vulns(
         .ok_or_else(|| {
             Box::new(
                 err_msg(format!(
-                    "Error reading compressed size from {}",
-                    meta_filename
+                        "Error reading compressed size from {}",
+                        meta_filename
                 ))
                 .compat(),
             )
         })
-        .map(|capture| capture.as_str())?;
+    .map(|capture| capture.as_str())?;
 
-    let hash = META_SHA256_RE
-        .captures(&meta_resp_text)
-        .and_then(|captures| captures.get(1))
-        .ok_or_else(|| {
-            Box::new(err_msg(format!("Error reading sha256 hash from {}", meta_filename)).compat())
-        })
-        .map(|capture| capture.as_str())?;
+let hash = META_SHA256_RE
+    .captures(&meta_resp_text)
+    .and_then(|captures| captures.get(1))
+    .ok_or_else(|| {
+        Box::new(err_msg(format!("Error reading sha256 hash from {}", meta_filename)).compat())
+    })
+.map(|capture| capture.as_str())?;
 
     if last_updated_time.is_none()
         || last_updated_time
@@ -439,11 +440,11 @@ fn download_and_parse_vulns(
 
         if hash != computed_hash {
             return Err(Box::new(
-                err_msg(format!(
-                    "Hash mismatch for {}, expected {}, got {}",
-                    data_filename, hash, computed_hash
-                ))
-                .compat(),
+                    err_msg(format!(
+                            "Hash mismatch for {}, expected {}, got {}",
+                            data_filename, hash, computed_hash
+                    ))
+                    .compat(),
             ));
         }
 
@@ -500,9 +501,9 @@ fn download_and_parse_vulns(
 
                 (
                     vuln_info["cve"]["CVE_data_meta"]["ID"]
-                        .as_str()
-                        .unwrap()
-                        .to_string(),
+                    .as_str()
+                    .unwrap()
+                    .to_string(),
                     VulnData {
                         advisory_str: compr_adv_text,
                         advisory_url: adv_url,
@@ -510,9 +511,9 @@ fn download_and_parse_vulns(
                     },
                 )
             })
-            .collect::<HashMap<_, _>>();
+        .collect::<HashMap<_, _>>();
 
-        return Ok(Some(cve_items));
+    return Ok(Some(cve_items));
     }
 
     Ok(None)
@@ -528,13 +529,13 @@ fn parse_tool_report(
             parse_bundler_audit_plaintext(&report, &vulns)
         } else {
             Err(Box::new(
-                err_msg(format!(
-                    "Unknown output format for Bundler-audit in ToolReport: {:?}",
-                    report
-                ))
-                .compat(),
+                    err_msg(format!(
+                            "Unknown output format for Bundler-audit in ToolReport: {:?}",
+                            report
+                    ))
+                    .compat(),
             )
-            .into())
+                .into())
         }
     } else if report.tool_name == "safety" {
         if report.output_format == "JSON" {
@@ -550,13 +551,13 @@ fn parse_tool_report(
                 .into())
         } else {
             Err(Box::new(
-                err_msg(format!(
-                    "Unknown output format for safety in ToolReport: {:?}",
-                    report
-                ))
-                .compat(),
+                    err_msg(format!(
+                            "Unknown output format for safety in ToolReport: {:?}",
+                            report
+                    ))
+                    .compat(),
             )
-            .into())
+                .into())
         }
     } else {
         Err(Box::new(err_msg(format!("Unknown tool in ToolReport: {:?}", report)).compat()).into())
@@ -592,11 +593,11 @@ fn parse_bundler_audit_plaintext(
             .collect::<HashMap<_, _>>();
         let advisory_id = AdvisoryId::try_from(
             fields
-                .get("Advisory")
-                .cloned()
-                .or_else(|| Some("".to_string()))
-                .unwrap()
-                .to_owned(),
+            .get("Advisory")
+            .cloned()
+            .or_else(|| Some("".to_string()))
+            .unwrap()
+            .to_owned(),
         )?;
 
         let default_cvss = Cvss::builder()
@@ -618,36 +619,36 @@ fn parse_bundler_audit_plaintext(
             timestamp: Timestamp::try_from(report.end_time.to_string())?,
             affected_package: AffectedPackage::try_from(
                 fields
-                    .get("Name")
-                    .cloned()
-                    .or_else(|| Some("".to_string()))
-                    .unwrap()
-                    .to_owned(),
+                .get("Name")
+                .cloned()
+                .or_else(|| Some("".to_string()))
+                .unwrap()
+                .to_owned(),
             )?,
             installed_version: InstalledVersion::try_from(
                 fields
-                    .get("Version")
-                    .cloned()
-                    .or_else(|| Some("".to_string()))
-                    .unwrap()
-                    .to_owned(),
+                .get("Version")
+                .cloned()
+                .or_else(|| Some("".to_string()))
+                .unwrap()
+                .to_owned(),
             )?,
             advisory_url: AdvisoryUrl::try_from(
                 fields
-                    .get("URL")
-                    .cloned()
-                    .or_else(|| Some("".to_string()))
-                    .unwrap()
-                    .to_owned(),
+                .get("URL")
+                .cloned()
+                .or_else(|| Some("".to_string()))
+                .unwrap()
+                .to_owned(),
             )?,
             advisory_id,
             advisory_description: AdvisoryDescription::try_from(
                 fields
-                    .get("Title")
-                    .cloned()
-                    .or_else(|| Some("".to_owned()))
-                    .unwrap()
-                    .to_owned(),
+                .get("Title")
+                .cloned()
+                .or_else(|| Some("".to_owned()))
+                .unwrap()
+                .to_owned(),
             )?,
             cvss: cvss.clone(),
             suppressed: false,
@@ -717,14 +718,14 @@ fn download_and_parse_python_safety_vulns(
         }
     } else {
         return Err(Box::new(
-            err_msg(format!(
-                "Unable to grab head from python safety database: ({})",
-                head_resp.status()
-            ))
-            .compat(),
+                err_msg(format!(
+                        "Unable to grab head from python safety database: ({})",
+                        head_resp.status()
+                ))
+                .compat(),
         )
-        .into());
-    }
+            .into());
+        }
 
     let meta_resp_text = reqwest::blocking::get(safety_json_db_url)?.text()?;
     let python_safety_vuln_info_json: HashMap<String, SafetyJsonData> =
@@ -735,11 +736,11 @@ fn download_and_parse_python_safety_vulns(
             SafetyJsonData::Vuln(_s) => true,
             _ => false,
         })
-        .map(|s| match s {
-            SafetyJsonData::Vuln(s) => s.iter(),
-            _ => unreachable!(),
-        })
-        .collect::<Vec<_>>()
+    .map(|s| match s {
+        SafetyJsonData::Vuln(s) => s.iter(),
+        _ => unreachable!(),
+    })
+    .collect::<Vec<_>>()
         .into_iter()
         .flatten()
         .collect::<Vec<_>>()
@@ -748,8 +749,8 @@ fn download_and_parse_python_safety_vulns(
             Value::String(s) => (p.id.to_owned(), Some(s.to_owned())),
             _ => (p.id.to_owned(), None),
         })
-        .collect::<HashMap<_, _>>();
-    Ok(Some(cve_items))
+    .collect::<HashMap<_, _>>();
+Ok(Some(cve_items))
 }
 
 fn parse_safety_json(
@@ -768,32 +769,33 @@ fn parse_safety_json(
             .unwrap();
 
         let mut advisory_str = vuln.advisory_description.to_string();
-        let mut advisory_url =
-            "https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json".to_string();
+        let mut advisory_url = PYTHON_SAFETY_VULN_URL.to_string();
         let mut cvss = &default_cvss;
 
         match safety_vulns
             .get(&format!("pyup.io-{}", advisory_id.to_string()))
-            .unwrap()
-        {
-            Some(s) => {
-                let cve_vec = s.split(',').collect::<Vec<&str>>();
-                for cve_str in cve_vec {
-                    cvss = vulns.get(cve_str).map_or(&default_cvss, |v| &v.cvss);
-                    advisory_str = vulns
-                        .get(cve_str)
-                        .map_or(vuln.advisory_description.to_string(), |v| {
-                            v.advisory_str.to_string()
-                        });
-                    advisory_url = vulns.get(cve_str).map_or(
-                        "https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json"
-                            .to_string(),
-                        |v| v.advisory_url.to_string(),
-                    );
-                }
-            }
-            _ => (),
-        };
+            {
+                Some(res) => 
+                    match res { 
+                        Some(s) => {
+                            let cve_vec = s.split(',').collect::<Vec<&str>>();
+                            for cve_str in cve_vec {
+                                cvss = vulns.get(cve_str).map_or(&default_cvss, |v| &v.cvss);
+                                advisory_str = vulns
+                                    .get(cve_str)
+                                    .map_or(vuln.advisory_description.to_string(), |v| {
+                                        v.advisory_str.to_string()
+                                    });
+                                advisory_url = vulns.get(cve_str).map_or(
+                                    PYTHON_SAFETY_VULN_URL.to_string(),
+                                    |v| v.advisory_url.to_string(),
+                                );
+                            }
+                        }
+                        _ => (),
+                    },
+                None => ()
+            };
         let mut event = DependencyEvent {
             event_version: EventVersion::try_from("1".to_string())?,
             event_id: EventID::try_from(Uuid::new_v4().to_hyphenated().to_string())?,
@@ -855,7 +857,7 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
@@ -869,15 +871,15 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![SuppressedIssue {
             issue_hash: IssueHash::try_from(
-                "a441b688fb60942c701fbcee0f30c66c0f7b22da7f0b4c51488488d2a2b64197".to_owned(),
-            )
-            .unwrap(),
-            expiry_date: ExpiryDate::from(None),
-            suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-            suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                            "a441b688fb60942c701fbcee0f30c66c0f7b22da7f0b4c51488488d2a2b64197".to_owned(),
+                        )
+                .unwrap(),
+                expiry_date: ExpiryDate::from(None),
+                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
         }];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
@@ -891,26 +893,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 20).and_hms(12, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 20).and_hms(12, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "46a9d5bde718bf366178313019f04a753bad00685d38e3ec81c8628f35dfcb1b".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                                "46a9d5bde718bf366178313019f04a753bad00685d38e3ec81c8628f35dfcb1b".to_owned(),
+                            )
+                    .unwrap(),
+                    expiry_date: ExpiryDate::from(None),
+                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -926,26 +928,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(0, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(0, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "9cf8847d2992e7219e659cdde1969e0d567ebab39a7aba13b36f9916fa26f6ca".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                                "9cf8847d2992e7219e659cdde1969e0d567ebab39a7aba13b36f9916fa26f6ca".to_owned(),
+                            )
+                    .unwrap(),
+                    expiry_date: ExpiryDate::from(None),
+                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -961,26 +963,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 18).and_hms(10, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 18).and_hms(10, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "b100dabbadeedabbad1eadabbadeedabbad1edabbadeedabbad1eadabbadeeda".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                                "b100dabbadeedabbad1eadabbadeedabbad1edabbadeedabbad1eadabbadeeda".to_owned(),
+                            )
+                    .unwrap(),
+                    expiry_date: ExpiryDate::from(None),
+                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -996,26 +998,26 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(None),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "a41f58ced5996b018dfbd697c1b16675f0cf864a3475d237cdd3f4d8c7160fdb".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(None),
-                suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                                "a41f58ced5996b018dfbd697c1b16675f0cf864a3475d237cdd3f4d8c7160fdb".to_owned(),
+                            )
+                    .unwrap(),
+                    expiry_date: ExpiryDate::from(None),
+                    suppression_reason: SuppressionReason::try_from("Test issue".to_owned()).unwrap(),
+                    suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
         ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
@@ -1031,29 +1033,29 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 19).and_hms(12, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 19).and_hms(12, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
-        ];
+            ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
             true,
@@ -1067,29 +1069,29 @@ mod tests {
         let test_hash = IssueHash::try_from(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         )
-        .unwrap();
+            .unwrap();
         let suppressed_issues: Vec<SuppressedIssue> = vec![
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(12, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 05, 17).and_hms(12, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
             SuppressedIssue {
                 issue_hash: IssueHash::try_from(
-                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
-                )
-                .unwrap(),
-                expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
-                suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+                            )
                     .unwrap(),
-                suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
+                    expiry_date: ExpiryDate::from(Some(Utc.ymd(2020, 07, 19).and_hms(12, 0, 0))),
+                    suppression_reason: SuppressionReason::try_from("Matching issue".to_owned())
+                        .unwrap(),
+                        suppressed_by: SuppressedBy::try_from("Dan Murphy".to_owned()).unwrap(),
             },
-        ];
+            ];
         let test_date = Utc.ymd(2020, 05, 18).and_hms(12, 00, 00);
         assert_eq!(
             true,
@@ -1108,7 +1110,7 @@ mod tests {
         let client = Client::new();
         assert!(
             download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client)
-                .is_err(),
+            .is_err(),
             "HTTP error status not handled correctly"
         );
         mock.assert_hits(1);
@@ -1123,7 +1125,6 @@ mod tests {
             then.status(200)
                 .header("Connection", "keep-alive")
                 .header("Content-Length", "348")
-                .header("Content-Type", "text/plain; charset=utf-8")
                 .header("Cache-Control", "max-age=300")
                 .header(
                     "Content-Security-Policy",
@@ -1133,27 +1134,6 @@ mod tests {
                     "ETag",
                     "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
                 )
-                .header("Strict-Transport-Security", "max-age=31536000")
-                .header("X-Content-Type-Options", "nosniff")
-                .header("X-Frame-Options", "deny")
-                .header("X-XSS-Protection", "1; mode=block")
-                .header("Via", "1.1 varnish (Varnish/6.0), 1.1 varnish")
-                .header("Content-Encoding", "gzip")
-                .header("X-GitHub-Request-Id", "2DD2:2A31:366058:393F4A:5FC8BA35")
-                .header("Accept-Ranges", "bytes")
-                .header("Date", "Thu, 03 Dec 2020 12:05:06 GMT")
-                .header("X-Served-By", "cache-lcy19250-LCY")
-                .header("X-Cache", "HFM, HIT")
-                .header("X-Cache-Hits", "0, 1")
-                .header("X-Timer", "S1606997106.156669,VS0,VE1")
-                .header("Vary", "Authorization,Accept-Encoding, Accept-Encoding")
-                .header("Access-Control-Allow-Origin", "*")
-                .header(
-                    "X-Fastly-Request-ID",
-                    "4d1a4685623b535c8417cc2dfab67794968e04a6",
-                )
-                .header("Expires", "Thu, 03 Dec 2020 12:10:06 GMT")
-                .header("Source-Age", "129")
                 .json_body(json!({
                     "$meta": {
                         "advisory": "PyUp.io metadata",
@@ -1186,6 +1166,7 @@ mod tests {
         let client = Client::new();
         let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
         assert!(etag.is_some());
+        assert!(etag.unwrap() == "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"");
         assert!(
             res.is_ok(),
             "Error result was produced when dealing with a None Etag"
@@ -1197,7 +1178,7 @@ mod tests {
         );
         let vhash = res_ok.unwrap();
         assert!(
-            vhash.len() > 0,
+            vhash.is_empty() == false,
             "Incorrect number of elements in the Python safety map"
         );
         assert!(
@@ -1222,34 +1203,9 @@ mod tests {
                 .header("Content-Type", "text/plain; charset=utf-8")
                 .header("Cache-Control", "max-age=300")
                 .header(
-                    "Content-Security-Policy",
-                    "default-src \"none\"; style-src \"unsafe-inline\"; sandbox",
-                )
-                .header(
                     "ETag",
                     "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d4038a05ba4f26\"",
                 )
-                .header("Strict-Transport-Security", "max-age=31536000")
-                .header("X-Content-Type-Options", "nosniff")
-                .header("X-Frame-Options", "deny")
-                .header("X-XSS-Protection", "1; mode=block")
-                .header("Via", "1.1 varnish (Varnish/6.0), 1.1 varnish")
-                .header("Content-Encoding", "gzip")
-                .header("X-GitHub-Request-Id", "2DD2:2A31:366058:393F4A:5FC8BA35")
-                .header("Accept-Ranges", "bytes")
-                .header("Date", "Thu, 03 Dec 2020 12:05:06 GMT")
-                .header("X-Served-By", "cache-lcy19250-LCY")
-                .header("X-Cache", "HFM, HIT")
-                .header("X-Cache-Hits", "0, 1")
-                .header("X-Timer", "S1606997106.156669,VS0,VE1")
-                .header("Vary", "Authorization,Accept-Encoding, Accept-Encoding")
-                .header("Access-Control-Allow-Origin", "*")
-                .header(
-                    "X-Fastly-Request-ID",
-                    "4d1a4685623b535c8417cc2dfab67794968e04a6",
-                )
-                .header("Expires", "Thu, 03 Dec 2020 12:10:06 GMT")
-                .header("Source-Age", "129")
                 .json_body(json!({
                     "$meta": {
                         "advisory": "PyUp.io metadata",
@@ -1283,7 +1239,8 @@ mod tests {
         let old_etag = etag.clone();
         let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
         assert!(etag.is_some());
-        assert!(old_etag != etag, "Etags cannot be matching");
+        assert!(old_etag.unwrap() != etag.clone().unwrap(), "Etags cannot be matching");
+        assert!(etag.unwrap() == "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d4038a05ba4f26\"");
         assert!(
             res.is_ok(),
             "Error result was produced when dealing with matching Etags"
@@ -1320,34 +1277,9 @@ mod tests {
                 .header("Content-Type", "text/plain; charset=utf-8")
                 .header("Cache-Control", "max-age=300")
                 .header(
-                    "Content-Security-Policy",
-                    "default-src \"none\"; style-src \"unsafe-inline\"; sandbox",
-                )
-                .header(
                     "ETag",
                     "\"3e557b6621332dd9eb4ee95322df0a2971c87322fdf56abaa1d6038a05ba4f26\"",
                 )
-                .header("Strict-Transport-Security", "max-age=31536000")
-                .header("X-Content-Type-Options", "nosniff")
-                .header("X-Frame-Options", "deny")
-                .header("X-XSS-Protection", "1; mode=block")
-                .header("Via", "1.1 varnish (Varnish/6.0), 1.1 varnish")
-                .header("Content-Encoding", "gzip")
-                .header("X-GitHub-Request-Id", "2DD2:2A31:366058:393F4A:5FC8BA35")
-                .header("Accept-Ranges", "bytes")
-                .header("Date", "Thu, 03 Dec 2020 12:05:06 GMT")
-                .header("X-Served-By", "cache-lcy19250-LCY")
-                .header("X-Cache", "HFM, HIT")
-                .header("X-Cache-Hits", "0, 1")
-                .header("X-Timer", "S1606997106.156669,VS0,VE1")
-                .header("Vary", "Authorization,Accept-Encoding, Accept-Encoding")
-                .header("Access-Control-Allow-Origin", "*")
-                .header(
-                    "X-Fastly-Request-ID",
-                    "4d1a4685623b535c8417cc2dfab67794968e04a6",
-                )
-                .header("Expires", "Thu, 03 Dec 2020 12:10:06 GMT")
-                .header("Source-Age", "129")
                 .json_body(json!({
                     "$meta": {
                         "advisory": "PyUp.io metadata",
@@ -1380,7 +1312,7 @@ mod tests {
         let client = Client::new();
         let old_etag = etag.clone();
         let res = download_and_parse_python_safety_vulns(server.url("/data"), &mut etag, &client);
-        assert!(old_etag == etag);
+        assert!(old_etag.unwrap() == etag.unwrap());
         assert!(
             res.is_ok(),
             "Error result was produced when dealing with a matching Etags"
@@ -1392,27 +1324,6 @@ mod tests {
         );
         mock.assert_hits(1);
     }
-
-    /*
-     #[test]
-    fn download_safety_vuln_db() { 
-        let client = Client::new();
-        let mut etag = None;
-        match download_and_parse_python_safety_vulns("https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json".to_string(), &mut etag, &client){ 
-            Err(e) => println!("Error downloading safety vulns: {} \n", e),
-            Ok(Some(vulnshash)) => { 
-                for (key,val) in &vulnshash {
-                    match val { 
-                        Some(cve) => 
-                            println!("{} --> {}", key,cve), 
-                        None => () 
-                    } 
-                }
-            },
-            Ok(None) => ()
-        }
-    } */
-
 
     #[test]
     fn parse_python_safety_vulns() {
@@ -1432,63 +1343,63 @@ mod tests {
         "38100"
     ]]"#;
 
-        let compr_adv_text = ComprString::new("Some advsiory text");
+    let advisory_text = "Some advsiory text"; 
+    let compr_adv_text = ComprString::new(advisory_text);
+    let advisory_url = "http://someurl.co.uk/";
 
-        let safety_cve_map: HashMap<String, Option<String>> = [(
-            "pyup.io-38414".to_string(),
-            Some("CVE-2020-13757".to_string()),
-        )]
+    let safety_cve_map: HashMap<String, Option<String>> = [(
+        "pyup.io-38414".to_string(),
+        Some("CVE-2020-13757".to_string()),
+    )]
         .iter()
         .cloned()
         .collect();
 
-        let vulnshash: HashMap<String, VulnData> = [(
-            "CVE-2020-13757".to_string(),
-            VulnData {
-                advisory_str: compr_adv_text,
-                advisory_url: "http://someurl.co.uk".to_string(),
-                cvss: Cvss::builder()
-                    .with_version(CvssVersion::V2)
-                    .with_score(Some(7.5))
-                    .build()
-                    .unwrap(),
-            },
-        )]
+    let vulnshash: HashMap<String, VulnData> = [(
+        "CVE-2020-13757".to_string(),
+        VulnData {
+            advisory_str: compr_adv_text,
+            advisory_url: advisory_url.to_string(),
+            cvss: Cvss::builder()
+                .with_version(CvssVersion::V2)
+                .with_score(Some(7.5))
+                .build()
+                .unwrap(),
+        },
+    )]
         .iter()
         .cloned()
         .collect();
-        let test_report = ToolReport {
-            event_version: EventVersion::try_from("1".to_owned()).unwrap(),
-            event_id: EventID::try_from("95130bee-95ae-4dac-aecf-5650ff646ea1".to_owned()).unwrap(),
-            application_name: ApplicationName::try_from("Test application".to_owned()).unwrap(),
-            git_branch: GitBranch::try_from(Some("git".to_owned())).unwrap(),
-            git_commit_hash: GitCommitHash::try_from(
-                "e99f715d0fe787cd43de967b8a79b56960fed3e5".to_owned(),
-            )
+    let test_report = ToolReport {
+        event_version: EventVersion::try_from("1".to_owned()).unwrap(),
+        event_id: EventID::try_from("95130bee-95ae-4dac-aecf-5650ff646ea1".to_owned()).unwrap(),
+        application_name: ApplicationName::try_from("Test application".to_owned()).unwrap(),
+        git_branch: GitBranch::try_from(Some("git".to_owned())).unwrap(),
+        git_commit_hash: GitCommitHash::try_from(
+            "e99f715d0fe787cd43de967b8a79b56960fed3e5".to_owned(),
+        )
             .unwrap(),
             tool_name: ToolName::try_from("safety".to_owned()).unwrap(),
             tool_output: ToolOutput::try_from(python_safety_vulns.to_owned()).unwrap(),
             output_format: OutputFormat::JSON,
             start_time: StartTime::from(DateTime::<Utc>::from(
-                DateTime::parse_from_rfc3339("2019-09-13T19:35:38+00:00").unwrap(),
+                    DateTime::parse_from_rfc3339("2019-09-13T19:35:38+00:00").unwrap(),
             )),
             end_time: EndTime::from(DateTime::<Utc>::from(
-                DateTime::parse_from_rfc3339("2019-09-13T19:37:14+00:00").unwrap(),
+                    DateTime::parse_from_rfc3339("2019-09-13T19:37:14+00:00").unwrap(),
             )),
             environment: Environment::Local,
             tool_version: ToolVersion::try_from(Some("1.0".to_owned())).unwrap(),
             suppressed_issues: vec![],
-        };
-        let events = parse_safety_json(&test_report, &vulnshash, &safety_cve_map);
-        for event in &events.unwrap() {
-            println!(
-                "affected package: {}, installed version: {}, cvss: {}, url: {},  advisory: {}\n",
-                event.affected_package,
-                event.installed_version,
-                event.cvss,
-                event.advisory_url,
-                event.advisory_description
-            )
-        }
+    };
+    let events_res = parse_safety_json(&test_report, &vulnshash, &safety_cve_map);
+    assert!(events_res.is_ok());
+    let events = events_res.unwrap();
+    assert_eq!(events.len(), 2);
+    assert!(events[0].affected_package.to_string() == "rsa");
+    assert!(events[0].advisory_url.to_string() == advisory_url);
+    assert!(events[0].advisory_description.to_string() == advisory_text); 
+    assert!(events[1].affected_package.to_string() == "pyyaml");
+    assert!(events[1].advisory_url.to_string() == PYTHON_SAFETY_VULN_URL);
     }
 }

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -725,7 +725,7 @@ fn download_and_parse_python_safety_vulns(
         .into());
     }
 
-    let safety_db_resp_text = reqwest::blocking::get(safety_json_db_url)?.text()?;
+    let safety_db_resp_text = reqwest::blocking::get(server_name)?.text()?;
     let python_safety_vuln_info_json: HashMap<String, SafetyJsonData> =
         serde_json::from_str(safety_db_resp_text.as_ref())?;
 

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -476,23 +476,21 @@ fn download_and_parse_vulns(
                     Cvss::builder().with_version(CvssVersion::Unknown).build()
                 };
 
-                let adv_text = vuln_info
+                let desc_data_arr = vuln_info
                     .get("cve")
                     .and_then(|cve| cve.get("description"))
-                    .and_then(|desc| desc.get("description_data"))
-                    .and_then(|desc_data| desc_data.get("value"))
-                    .unwrap()
-                    .to_string();
+                    .and_then(|desc| desc.get("description_data"));
 
-                let compr_adv_text = ComprString::new(&adv_text);
+                let adv = desc_data_arr.unwrap()[0]["value"].to_string();
 
-                let adv_url = vuln_info
+                let compr_adv_text = ComprString::new(&adv);
+
+                let adv_ref_arr = vuln_info
                     .get("cve")
-                    .and_then(|cve| cve.get("reference"))
-                    .and_then(|refer| refer.get("reference_data"))
-                    .and_then(|refer_data| refer_data.get("url"))
-                    .unwrap()
-                    .to_string();
+                    .and_then(|cve| cve.get("references"))
+                    .and_then(|refer| refer.get("reference_data"));
+
+                let adv_url_str = adv_ref_arr.unwrap()[0]["url"].to_string();
 
                 (
                     vuln_info["cve"]["CVE_data_meta"]["ID"]
@@ -501,7 +499,7 @@ fn download_and_parse_vulns(
                         .to_string(),
                     VulnData {
                         advisory_str: compr_adv_text,
-                        advisory_url: adv_url,
+                        advisory_url: adv_url_str,
                         cvss: cvss.unwrap(),
                     },
                 )

--- a/tool-images/python/safety/Dockerfile
+++ b/tool-images/python/safety/Dockerfile
@@ -9,11 +9,6 @@ RUN ["chmod", "+x", "/entrypoint.sh"]
 COPY data-forwarder /data-forwarder
 RUN ["chmod", "+x", "/data-forwarder"]
 
-RUN apk add --no-cache --virtual .pynacl_deps build-base python3-dev libffi-dev openssl-dev
 RUN pip install safety
-RUN pip install insecure-package
-RUN pip install 'blackduck==0.0.50'
-RUN pip install distro
-RUn pip install django=='1.11.22'
 
 CMD ["/entrypoint.sh"]

--- a/tool-images/python/safety/Dockerfile
+++ b/tool-images/python/safety/Dockerfile
@@ -9,6 +9,6 @@ RUN ["chmod", "+x", "/entrypoint.sh"]
 COPY data-forwarder /data-forwarder
 RUN ["chmod", "+x", "/data-forwarder"]
 
-RUN pip install safety
+RUN pip install safety=='1.10.3'
 
 CMD ["/entrypoint.sh"]

--- a/tool-images/python/safety/Dockerfile
+++ b/tool-images/python/safety/Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE=python:3.10-rc-alpine
+FROM $BASE_IMAGE
+RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add git
+WORKDIR /code
+
+COPY entrypoint.sh /entrypoint.sh
+RUN ["chmod", "+x", "/entrypoint.sh"]
+COPY data-forwarder /data-forwarder
+RUN ["chmod", "+x", "/data-forwarder"]
+
+RUN apk add --no-cache --virtual .pynacl_deps build-base python3-dev libffi-dev openssl-dev
+RUN pip install safety
+RUN pip install insecure-package
+RUN pip install 'blackduck==0.0.50'
+RUN pip install distro
+RUn pip install django=='1.11.22'
+
+CMD ["/entrypoint.sh"]

--- a/tool-images/python/safety/Makefile.toml
+++ b/tool-images/python/safety/Makefile.toml
@@ -1,0 +1,60 @@
+[env]
+GIT_SHA = { script = ["git rev-parse --short HEAD"] }
+GIT_BRANCH = { script = ["git rev-parse --abbrev-ref HEAD"] }
+
+[tasks.pre-build-safety-docker]
+command = "cp"
+args = ["../../../bin/data-forwarder", "data-forwarder"]
+
+[tasks.post-build-safety-docker]
+command = "rm"
+args = ["data-forwarder"]
+
+[tasks.build-safety-docker]
+dependencies = ["pre-build-safety-docker"]
+command = "docker"
+args = ["build", "-t", "kiln/safety:${GIT_BRANCH}-${GIT_SHA}", "."]
+
+[tasks.build-safety-git-docker]
+dependencies = ["build-safety-docker-tag-git-version", "build-safety-docker-tag-git-latest"]
+
+[tasks.build-safety-docker-tag-git-version]
+command = "docker"
+args = ["build", "-t", "kiln/safety:git-${GIT_SHA}", "."]
+
+[tasks.safety-docker-push-git-version]
+command = "docker"
+args = ["push", "kiln/safety:git-${GIT_SHA}"]
+
+[tasks.build-safety-docker-tag-git-latest]
+command = "docker"
+args = ["tag", "kiln/safety:git-${GIT_SHA}", "kiln/safety:git-latest"]
+
+[tasks.safety-docker-push-git-latest]
+command = "docker"
+args = ["push", "kiln/safety:git-latest"]
+
+[tasks.build-safety-release-docker]
+dependencies = ["build-safety-docker-tag-release-version", "build-safety-docker-tag-release-latest"]
+
+[tasks.build-safety-docker-tag-release-version]
+script = [
+	"GIT_TAG=git rev-parse --abbrev-ref HEAD",
+	"docker build -t kiln/safety:$GIT_TAG ."
+]
+
+[tasks.safety-docker-push-release-version]
+script = [
+	"GIT_TAG=git rev-parse --abbrev-ref HEAD",
+	"docker push kiln/safety:$GIT_TAG"
+]
+
+[tasks.build-safety-docker-tag-release-latest]
+script = [
+	"GIT_TAG=git rev-parse --abbrev-ref HEAD",
+	"docker tag kiln/safety:$GIT_TAG kiln/safety:latest"
+]
+
+[tasks.safety-docker-push-release-latest]
+command = "docker"
+args = ["push", "kiln/safety:latest"]

--- a/tool-images/python/safety/entrypoint.sh
+++ b/tool-images/python/safety/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-START_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
 FILE_NAME=$(mktemp -t -p . tool-output.XXXXXXXXXX)
-safety check --json | tee $FILE_NAME
-END_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
-pip uninstall insecure-package
-pip uninstall blackduck
-pip uninstall django
-/data-forwarder --tool-name=safety --tool-version=0.6.1 --tool-output-path="$FILE_NAME" --start-time="$START_TIME" --end-time="$END_TIME" --output-format=JSON --scan-env="$SCAN_ENV" --app-name="$APP_NAME" --endpoint-url="$DATA_COLLECTOR_URL"
-rm $FILE_NAME
+REQ_FILE_NAME=requirements.txt
+if test -f "$REQ_FILE_NAME"; then 
+    START_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
+    safety check --json -r requirements.txt | tee $FILE_NAME
+    END_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
+    /data-forwarder --tool-name=safety --tool-version=0.6.1 --tool-output-path="$FILE_NAME" --start-time="$START_TIME" --end-time="$END_TIME" --output-format=JSON --scan-env="$SCAN_ENV" --app-name="$APP_NAME" --endpoint-url="$DATA_COLLECTOR_URL"
+    rm $FILE_NAME
+fi

--- a/tool-images/python/safety/entrypoint.sh
+++ b/tool-images/python/safety/entrypoint.sh
@@ -5,6 +5,6 @@ if test -f "$REQ_FILE_NAME"; then
     START_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
     safety check --json -r requirements.txt | tee $FILE_NAME
     END_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
-    /data-forwarder --tool-name=safety --tool-version=0.6.1 --tool-output-path="$FILE_NAME" --start-time="$START_TIME" --end-time="$END_TIME" --output-format=JSON --scan-env="$SCAN_ENV" --app-name="$APP_NAME" --endpoint-url="$DATA_COLLECTOR_URL"
+    /data-forwarder --tool-name=safety --tool-version=1.10.3 --tool-output-path="$FILE_NAME" --start-time="$START_TIME" --end-time="$END_TIME" --output-format=JSON --scan-env="$SCAN_ENV" --app-name="$APP_NAME" --endpoint-url="$DATA_COLLECTOR_URL"
     rm $FILE_NAME
 fi

--- a/tool-images/python/safety/entrypoint.sh
+++ b/tool-images/python/safety/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+START_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
+FILE_NAME=$(mktemp -t -p . tool-output.XXXXXXXXXX)
+safety check --json | tee $FILE_NAME
+END_TIME=$(date -I'seconds' | sed "s/\(.*\)\(.\{2\}\)$/\1:\2/")
+pip uninstall insecure-package
+pip uninstall blackduck
+pip uninstall django
+/data-forwarder --tool-name=safety --tool-version=0.6.1 --tool-output-path="$FILE_NAME" --start-time="$START_TIME" --end-time="$END_TIME" --output-format=JSON --scan-env="$SCAN_ENV" --app-name="$APP_NAME" --endpoint-url="$DATA_COLLECTOR_URL"
+rm $FILE_NAME


### PR DESCRIPTION
# What does this PR change?
It introduces support for the python Safety dependency checker into report parser.

# Why is it important?
Python projects can be checked for dependencies on vulnerable packages.

# Checklist
- [x] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
