### PR TITLE
Report-parser: Replace hardcoded year for data range with current year when pulling NIST NVD data

### DIFF
--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .build()?;
 
     let mut vulns = HashMap::new();
-    for year in 2002..=Utc::today().year(){
+    for year in 2002..=Utc::today().year() {
         download_and_parse_vulns(year.to_string(), last_updated_time, &base_url, &client)
             .map_err(|err| {
                 error!(error_logger, "Error downloading vulns for {}", year;

--- a/report-parser/src/main.rs
+++ b/report-parser/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .build()?;
 
     let mut vulns = HashMap::new();
-    for year in 2002..=2020 {
+    for year in 2002..=Utc::today().year(){
         download_and_parse_vulns(year.to_string(), last_updated_time, &base_url, &client)
             .map_err(|err| {
                 error!(error_logger, "Error downloading vulns for {}", year;


### PR DESCRIPTION
# What does this PR change?
- Ensures that the report parser will fetch data from the NIST NVD after 2020

# Why is it important?
- To maintain an up to date cache of vulnerability data

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
