### PR TITLE
Fix data collector log source ip

### DIFF
--- a/data-collector/src/lib.rs
+++ b/data-collector/src/lib.rs
@@ -16,6 +16,7 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
+use std::str::FromStr;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 use uuid::Uuid;
@@ -109,7 +110,8 @@ where
             let source_ip = req
                 .connection_info()
                 .remote()
-                .map_or(String::from("-"), ToOwned::to_owned);
+                .and_then(|conn_info| std::net::SocketAddr::from_str(conn_info).ok())
+                .map_or_else(|| String::from("-"), |socket_addr| socket_addr.ip().to_string());
 
             let url_domain = req
                 .headers()

--- a/data-collector/src/lib.rs
+++ b/data-collector/src/lib.rs
@@ -16,8 +16,8 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
-use std::str::FromStr;
 use std::rc::Rc;
+use std::str::FromStr;
 use std::task::{Context, Poll};
 use uuid::Uuid;
 
@@ -111,7 +111,10 @@ where
                 .connection_info()
                 .remote()
                 .and_then(|conn_info| std::net::SocketAddr::from_str(conn_info).ok())
-                .map_or_else(|| String::from("-"), |socket_addr| socket_addr.ip().to_string());
+                .map_or_else(
+                    || String::from("-"),
+                    |socket_addr| socket_addr.ip().to_string(),
+                );
 
             let url_domain = req
                 .headers()


### PR DESCRIPTION
# What does this PR change?
- Ensures that Data-collector ECS format logs conform to the format. Previously, Source.IP was including the source port, which is not compliant

# Why is it important?
- Correct logging output

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
