### PR TITLE
Use latest stable musl builder image

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -15,17 +15,17 @@ dependencies = [
 command = "cargo"
 args = ["make", "--cwd", "cli", "build-kiln-cli"]
 
-[tasks.build-data-collector-docker]
+[tasks.build-data-collector-git-docker]
 command = "cargo"
-args = ["make", "--cwd", "data-collector", "build-data-collector-docker"]
+args = ["make", "--cwd", "data-collector", "build-data-collector-git-docker"]
 
-[tasks.build-report-parser-docker]
+[tasks.build-report-parser-git-docker]
 command = "cargo"
-args = ["make", "--cwd", "report-parser", "build-report-parser-docker"]
+args = ["make", "--cwd", "report-parser", "build-report-parser-git-docker"]
 
-[tasks.build-slack-connector-docker]
+[tasks.build-slack-connector-git-docker]
 command = "cargo"
-args = ["make", "--cwd", "slack-connector", "build-slack-connector-docker"]
+args = ["make", "--cwd", "slack-connector", "build-slack-connector-git-docker"]
 
 [tasks.build-data-forwarder-musl]
 command = "cargo"

--- a/cli/Makefile.toml
+++ b/cli/Makefile.toml
@@ -37,8 +37,8 @@ script = [
 [tasks.musl-build]
 script = [
 	"mkdir target &> /dev/null || true",
-	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
-	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 cargo build --release"
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable cargo build --release"
 ]
 
 [tasks.copy-binary-to-root-dir]

--- a/data-collector/Makefile.toml
+++ b/data-collector/Makefile.toml
@@ -18,8 +18,8 @@ dependencies = [
 [tasks.musl-build]
 script = [
 	"mkdir target &> /dev/null || true",
-	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
-	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 cargo build --release"
+#	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable cargo build --release"
 ]
 
 [tasks.build-data-collector-docker-image]

--- a/data-forwarder/Makefile.toml
+++ b/data-forwarder/Makefile.toml
@@ -13,8 +13,8 @@ dependencies = [
 [tasks.musl-build]
 script = [
 	"mkdir target &> /dev/null || true",
-	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
-	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 cargo build --release"
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable cargo build --release"
 ] 
 
 [tasks.copy-binary-to-root-dir]

--- a/report-parser/Makefile.toml
+++ b/report-parser/Makefile.toml
@@ -18,8 +18,8 @@ dependencies = [
 [tasks.musl-build]
 script = [
 	"mkdir target &> /dev/null || true",
-	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
-	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 cargo build --release"
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable cargo build --release"
 ]
 
 [tasks.build-report-parser-docker-image]

--- a/slack-connector/Makefile.toml
+++ b/slack-connector/Makefile.toml
@@ -18,8 +18,8 @@ dependencies = [
 [tasks.musl-build]
 script = [
 	"mkdir target &> /dev/null || true",
-	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
-	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable-openssl11 cargo build --release"
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry /home/rust/src/target",
+	"docker run --rm -v $PWD:/home/rust/src -v cargo-git:/home/rust/.cargo/git -v cargo-registry:/home/rust/.cargo/registry ekidd/rust-musl-builder:stable cargo build --release"
 ]
 
 [tasks.build-slack-connector-docker-image]


### PR DESCRIPTION
# What does this PR change?
- Switch to using latest stable docker image for musl builds instead of the old stable-openssl11 tag
- Fix makefile targets in top-level makefile

# Why is it important?
- Tracking latest stable Rust and linking against current releases of OpenSSL

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
