### PR TITLE
Kiln lib kafka thiserror

### DIFF
--- a/kiln_lib/Cargo.lock
+++ b/kiln_lib/Cargo.lock
@@ -885,6 +885,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-async",
+ "thiserror",
  "tokio",
  "toml",
  "url",

--- a/kiln_lib/Cargo.toml
+++ b/kiln_lib/Cargo.toml
@@ -22,6 +22,7 @@ toml_crate = { version = "0.5", package = "toml", optional = true }
 openssl-probe = "0.1"
 json_dotpath = { version = "1", optional = true }
 slog = { version = "2.5", features = [ "nested-values",], optional = true }
+thiserror = "1"
 
 [features]
 default = []

--- a/kiln_lib/src/kafka.rs
+++ b/kiln_lib/src/kafka.rs
@@ -6,7 +6,6 @@ use rdkafka::error::KafkaError;
 use rdkafka::producer::future_producer::FutureProducer;
 use std::fmt::Display;
 
-
 #[derive(Debug, Clone)]
 pub struct KafkaBootstrapTlsConfig(Vec<String>);
 
@@ -22,7 +21,7 @@ impl Display for ValidationFailureReason {
         match self {
             ValidationFailureReason::Missing => f.write_str("value is missing"),
             ValidationFailureReason::PresentButEmpty => f.write_str("value is present but empty"),
-            ValidationFailureReason::CouldNotBeParsed => f.write_str("value could not be parsed")
+            ValidationFailureReason::CouldNotBeParsed => f.write_str("value could not be parsed"),
         }
     }
 }
@@ -30,9 +29,15 @@ impl Display for ValidationFailureReason {
 #[derive(thiserror::Error, Debug)]
 pub enum KafkaConfigError {
     #[error("Required environment variable {var} failed validation because {reason}")]
-    RequiredValueValidationFailure { var: String, reason: ValidationFailureReason},
+    RequiredValueValidationFailure {
+        var: String,
+        reason: ValidationFailureReason,
+    },
     #[error("Optional environment variable {var} failed validation because {reason}")]
-    OptionalValueValidationFailure { var: String, reason: ValidationFailureReason},
+    OptionalValueValidationFailure {
+        var: String,
+        reason: ValidationFailureReason,
+    },
     #[error("Kafka client could not be created")]
     KafkaError(#[from] KafkaError),
     #[error("Could not find TLS trust store")]
@@ -53,7 +58,7 @@ where
             if var.1.is_empty() {
                 return Err(KafkaConfigError::OptionalValueValidationFailure {
                     var: "DISABLE_KAFKA_DOMAIN_VALIDATION".into(),
-                    reason: ValidationFailureReason::PresentButEmpty
+                    reason: ValidationFailureReason::PresentButEmpty,
                 });
             } else {
                 match var.1.as_ref() {
@@ -77,7 +82,7 @@ where
             if var.1.is_empty() {
                 return Err(KafkaConfigError::RequiredValueValidationFailure {
                     var: "KAFKA_BOOTSTRAP_TLS".into(),
-                    reason: ValidationFailureReason::PresentButEmpty
+                    reason: ValidationFailureReason::PresentButEmpty,
                 });
             } else {
                 let raw_hosts: Vec<String> = var.1.split(',').map(|s| s.to_owned()).collect();

--- a/kiln_lib/src/kafka.rs
+++ b/kiln_lib/src/kafka.rs
@@ -4,11 +4,42 @@ use rdkafka::config::ClientConfig;
 use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::error::KafkaError;
 use rdkafka::producer::future_producer::FutureProducer;
+use std::fmt::Display;
+
 
 #[derive(Debug, Clone)]
 pub struct KafkaBootstrapTlsConfig(Vec<String>);
 
-pub fn get_bootstrap_config<I>(vars: &mut I) -> Result<KafkaBootstrapTlsConfig, String>
+#[derive(Debug)]
+pub enum ValidationFailureReason {
+    Missing,
+    PresentButEmpty,
+    CouldNotBeParsed,
+}
+
+impl Display for ValidationFailureReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidationFailureReason::Missing => f.write_str("value is missing"),
+            ValidationFailureReason::PresentButEmpty => f.write_str("value is present but empty"),
+            ValidationFailureReason::CouldNotBeParsed => f.write_str("value could not be parsed")
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum KafkaConfigError {
+    #[error("Required environment variable {var} failed validation because {reason}")]
+    RequiredValueValidationFailure { var: String, reason: ValidationFailureReason},
+    #[error("Optional environment variable {var} failed validation because {reason}")]
+    OptionalValueValidationFailure { var: String, reason: ValidationFailureReason},
+    #[error("Kafka client could not be created")]
+    KafkaError(#[from] KafkaError),
+    #[error("Could not find TLS trust store")]
+    TlsTrustStore,
+}
+
+pub fn get_bootstrap_config<I>(vars: &mut I) -> Result<KafkaBootstrapTlsConfig, KafkaConfigError>
 where
     I: Iterator<Item = (String, String)>,
 {
@@ -20,28 +51,34 @@ where
         None => Ok(false),
         Some(var) => {
             if var.1.is_empty() {
-                return Err(
-                    "Optional environment variable present but empty: DISABLE_KAFKA_DOMAIN_VALIDATION"
-                        .to_owned(),
-                );
+                return Err(KafkaConfigError::OptionalValueValidationFailure {
+                    var: "DISABLE_KAFKA_DOMAIN_VALIDATION".into(),
+                    reason: ValidationFailureReason::PresentButEmpty
+                });
             } else {
                 match var.1.as_ref() {
                     "true" => Ok(true),
                     "false" => Ok(false),
-                    _ => Err("Optional environment variable did not pass validation: DISABLE_KAFKA_DOMAIN_VALIDATION".to_owned())
+                    _ => Err(KafkaConfigError::OptionalValueValidationFailure {
+                        var: "DISABLE_KAFKA_DOMAIN_VALIDATION".into(),
+                        reason: ValidationFailureReason::CouldNotBeParsed,
+                    }),
                 }
             }
         }
     }?;
 
     let kafka_bootstrap_tls = match local_vars.iter().find(|var| var.0 == "KAFKA_BOOTSTRAP_TLS") {
-        None => Err("Required environment variable missing: KAFKA_BOOTSTRAP_TLS".to_owned()),
+        None => Err(KafkaConfigError::RequiredValueValidationFailure {
+            var: "KAFKA_BOOTSTRAP_TLS".into(),
+            reason: ValidationFailureReason::Missing,
+        }),
         Some(var) => {
             if var.1.is_empty() {
-                return Err(
-                    "Required environment variable present but empty: KAFKA_BOOTSTRAP_TLS"
-                        .to_owned(),
-                );
+                return Err(KafkaConfigError::RequiredValueValidationFailure {
+                    var: "KAFKA_BOOTSTRAP_TLS".into(),
+                    reason: ValidationFailureReason::PresentButEmpty
+                });
             } else {
                 let raw_hosts: Vec<String> = var.1.split(',').map(|s| s.to_owned()).collect();
                 let valid = raw_hosts.iter().all(|x| {
@@ -57,10 +94,10 @@ where
                 if valid {
                     Ok(raw_hosts)
                 } else {
-                    Err(
-                        "KAFKA_BOOTSTRAP_TLS environment variable did not pass validation"
-                            .to_owned(),
-                    )
+                    Err(KafkaConfigError::RequiredValueValidationFailure {
+                        var: "KAFKA_BOOTSTRAP_TLS".into(),
+                        reason: ValidationFailureReason::CouldNotBeParsed,
+                    })
                 }
             }
         }
@@ -69,13 +106,15 @@ where
     Ok(KafkaBootstrapTlsConfig(kafka_bootstrap_tls))
 }
 
-pub fn build_kafka_producer(config: KafkaBootstrapTlsConfig) -> Result<FutureProducer, KafkaError> {
+pub fn build_kafka_producer(
+    config: KafkaBootstrapTlsConfig,
+) -> Result<FutureProducer, KafkaConfigError> {
     let cert_probe_result = openssl_probe::probe();
     let cert_location = match cert_probe_result {
-        ProbeResult { cert_file, .. } if cert_file.is_some() => cert_file,
-        ProbeResult { cert_dir, .. } if cert_dir.is_some() => cert_dir,
-        _ => panic!("Could not find TLS Certificate Store"),
-    };
+        ProbeResult { cert_file, .. } if cert_file.is_some() => Ok(cert_file),
+        ProbeResult { cert_dir, .. } if cert_dir.is_some() => Ok(cert_dir),
+        _ => Err(KafkaConfigError::TlsTrustStore),
+    }?;
 
     ClientConfig::new()
         .set("metadata.broker.list", &config.0.join(","))
@@ -84,18 +123,19 @@ pub fn build_kafka_producer(config: KafkaBootstrapTlsConfig) -> Result<FuturePro
         .set("ssl.cipher.suites", "ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256")
         .set("ssl.ca.location", cert_location.unwrap().to_string_lossy())
         .create()
+        .map_err(|err| err.into())
 }
 
 pub fn build_kafka_consumer(
     config: KafkaBootstrapTlsConfig,
     consumer_group_name: String,
-) -> Result<StreamConsumer, KafkaError> {
+) -> Result<StreamConsumer, KafkaConfigError> {
     let cert_probe_result = openssl_probe::probe();
     let cert_location = match cert_probe_result {
-        ProbeResult { cert_file, .. } if cert_file.is_some() => cert_file,
-        ProbeResult { cert_dir, .. } if cert_dir.is_some() => cert_dir,
-        _ => panic!("Could not find TLS Certificate Store"),
-    };
+        ProbeResult { cert_file, .. } if cert_file.is_some() => Ok(cert_file),
+        ProbeResult { cert_dir, .. } if cert_dir.is_some() => Ok(cert_dir),
+        _ => Err(KafkaConfigError::TlsTrustStore),
+    }?;
 
     ClientConfig::new()
         .set("metadata.broker.list", &config.0.join(","))
@@ -105,6 +145,7 @@ pub fn build_kafka_consumer(
         .set("ssl.cipher.suites", "ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256")
         .set("ssl.ca.location", cert_location.unwrap().to_string_lossy())
         .create()
+        .map_err(|err| err.into())
 }
 
 #[cfg(test)]
@@ -151,7 +192,7 @@ mod tests {
 
         assert_eq!(
             actual.to_string(),
-            "Required environment variable missing: KAFKA_BOOTSTRAP_TLS"
+            "Required environment variable KAFKA_BOOTSTRAP_TLS failed validation because value is missing"
         )
     }
 
@@ -164,7 +205,7 @@ mod tests {
 
         assert_eq!(
             actual.to_string(),
-            "Required environment variable present but empty: KAFKA_BOOTSTRAP_TLS"
+            "Required environment variable KAFKA_BOOTSTRAP_TLS failed validation because value is present but empty"
         )
     }
 
@@ -177,7 +218,7 @@ mod tests {
 
         assert_eq!(
             actual.to_string(),
-            "KAFKA_BOOTSTRAP_TLS environment variable did not pass validation"
+            "Required environment variable KAFKA_BOOTSTRAP_TLS failed validation because value could not be parsed"
         )
     }
 
@@ -209,7 +250,7 @@ mod tests {
 
         assert_eq!(
             actual.to_string(),
-            "KAFKA_BOOTSTRAP_TLS environment variable did not pass validation"
+            "Required environment variable KAFKA_BOOTSTRAP_TLS failed validation because value could not be parsed"
         )
     }
 
@@ -221,7 +262,7 @@ mod tests {
 
         assert_eq!(
             actual.to_string(),
-            "Optional environment variable present but empty: DISABLE_KAFKA_DOMAIN_VALIDATION"
+            "Optional environment variable DISABLE_KAFKA_DOMAIN_VALIDATION failed validation because value is present but empty"
         )
     }
 
@@ -237,7 +278,7 @@ mod tests {
 
         assert_eq!(
             actual.to_string(),
-            "Optional environment variable did not pass validation: DISABLE_KAFKA_DOMAIN_VALIDATION"
+            "Optional environment variable DISABLE_KAFKA_DOMAIN_VALIDATION failed validation because value could not be parsed"
         )
     }
 }


### PR DESCRIPTION
# What does this PR change?
Improves error handling in Kafka module of Kiln_lib so that consumers are working with an error enum that impl's the std::error::Error trait

# Why is it important?
Makes error handling clearer and more ergonomic in consuming code and allows us to use the anyhow crate

# Checklist
- [x] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
