### PR TITLE
Data collector missing request body fix

### DIFF
--- a/data-collector/src/lib.rs
+++ b/data-collector/src/lib.rs
@@ -3,21 +3,65 @@ use actix_web::dev::{
 };
 use actix_web::error::{Error, Result};
 use actix_web::http::header::{HOST, USER_AGENT};
+use actix_http::{error::PayloadError, h1::Payload as HttpPayload};
 use chrono::{SecondsFormat, Utc};
-use futures::future::{ok, Ready};
-use futures::stream::StreamExt;
+use futures::{future::{ok, Ready}, io::copy};
+use futures::stream::{Stream, StreamExt};
 use kiln_lib::validation::ValidationError;
 use serde::{Deserialize, Serialize};
 use slog::{error, info, o, Logger};
 use slog_derive::SerdeValue;
-use std::borrow::ToOwned;
+use std::{borrow::{BorrowMut, ToOwned}, ops::{Deref, DerefMut}};
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::str::FromStr;
+use std::task::Poll;
 use uuid::Uuid;
+
+#[derive(Clone)]
+struct CopyStream {
+    buffer: Rc<RefCell<Vec<u8>>>,
+    input: Rc<RefCell<actix_web::dev::Payload>>
+}
+
+impl Into<Pin<Box<dyn Stream<Item=Result<bytes::Bytes, PayloadError>>>>> for CopyStream {
+    fn into(self) -> Pin<Box<dyn Stream<Item=Result<bytes::Bytes, PayloadError>>>> {
+        Box::pin(self)
+    }
+}
+
+impl Stream for CopyStream {
+    type Item= Result<bytes::Bytes, PayloadError>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let mut input = self.input.deref().borrow_mut();
+        match input.deref_mut() {
+            actix_http::Payload::None => {
+                Poll::Ready(None)
+            },
+            actix_http::Payload::H1(ref mut p) => {
+                let res = p.readany(cx);
+                match res {
+                    Poll::Ready(b) => {
+                        if let Some(Ok(ref b)) = b {
+                            self.buffer.deref().borrow_mut().extend_from_slice(&b);
+                        }
+                        Poll::Ready(b)
+                    },
+                    Poll::Pending => Poll::Pending
+                }
+            },
+            actix_http::Payload::H2(p) => {todo!()},
+            actix_http::Payload::Stream(p) => {todo!()},
+        }
+    }
+}
 
 #[derive(Clone, SerdeValue, Serialize, Deserialize)]
 struct EventType(Vec<String>);
@@ -125,16 +169,32 @@ where
             // read request body
             let (req_http, mut payload) = req.into_parts();
 
-            let mut req_body_bytes_mut = bytes::BytesMut::new();
-            while let Some(chunk) = payload.by_ref().next().await {
-                req_body_bytes_mut.extend_from_slice(&chunk?);
-            }
-            let req_body_bytes = req_body_bytes_mut.freeze();
-            let req_body = String::from_utf8(req_body_bytes.clone().to_vec()).unwrap();
+            //let mut req_body_bytes_mut = bytes::BytesMut::new();
+            //while let Some(chunk) = payload.by_ref().next().await {
+            //    req_body_bytes_mut.extend_from_slice(&chunk?);
+            //}
+            //let req_body_bytes = req_body_bytes_mut.freeze();
+            //println!("{:?}", req_body_bytes);
+            //let req_body = String::from_utf8(req_body_bytes.clone().to_vec()).unwrap();
 
-            req = ServiceRequest::from_parts(req_http, payload);
+            //let (mut http_payload_sender, http_payload) = HttpPayload::create(true);
+
+            //http_payload_sender.feed_data(req_body_bytes.clone());
+            //println!("{:?}", http_payload);
+
+            let copy_payload = CopyStream {
+                buffer: Rc::new(RefCell::new(vec!())),
+                input: Rc::new(RefCell::new(payload))
+            };
+
+            let boxed_payload: Pin<Box<dyn Stream<Item=Result<bytes::Bytes, PayloadError>>>> = copy_payload.clone().into();
+
+            req = ServiceRequest::from_parts(req_http, boxed_payload.into());
 
             let resp = svc.call(req).await;
+
+            let req_body_bytes = copy_payload.buffer.deref().borrow();
+            let req_body = String::from_utf8((*req_body_bytes.deref()).clone()).unwrap();
 
             match resp {
                 Err(err) => {
@@ -251,5 +311,44 @@ where
                 }
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StructuredLogger;
+    use actix_web::test::TestRequest;
+    use kiln_lib::log::NestedJsonFmt;
+    use slog::o;
+    use slog::Drain;
+
+    #[tokio::test]
+    async fn request_logger_passes_through_request_body() {
+        let drain = NestedJsonFmt::new(std::io::sink()).fuse();
+        let drain = slog_async::Async::new(drain).build().fuse();
+        let root_logger = slog::Logger::root(
+            drain,
+            o!()
+        );
+        let sut = StructuredLogger::new(root_logger.clone()).exclude("/health");
+
+        let expected_body = "Test body";
+        let app = actix_web::test::init_service(
+            actix_web::App::new()
+                .wrap(sut)
+                .service(actix_web::web::resource("/test").to(move |actual_body: actix_web::web::Bytes| async move {
+                    println!("{:?}", expected_body);
+                    println!("{:?}", actual_body);
+                    assert_eq!(expected_body, actual_body);
+                    actix_web::HttpResponse::Ok()
+                }))
+        ).await;
+
+        // Create request object
+        let req = TestRequest::with_uri("/test").set_payload(expected_body).to_request();
+
+        // Call application
+        let resp = actix_web::test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
     }
 }


### PR DESCRIPTION
# What does this PR change?

- Fixes a bug in the Data-Collector that was causing the request logger to consume message bodies, resulting in all requests returning an error that the request body was empty

# Why is it important?

- Fixes a show-stopper bug for next release

# Checklist
- [x] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
