### PR TITLE
Data-forwarder: Detect branch name even when in detached head state

### DIFF
--- a/data-forwarder/src/main.rs
+++ b/data-forwarder/src/main.rs
@@ -132,7 +132,8 @@ fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         .output()
         .ok();
 
-    let git_branch_name = git_branch_name_cmd.map(|v| String::from_utf8_lossy(&v.stdout).into_owned());
+    let git_branch_name =
+        git_branch_name_cmd.map(|v| String::from_utf8_lossy(&v.stdout).into_owned());
     let git_commit = head.peel_to_commit()?.id().to_string();
 
     let kiln_cfg_path = PathBuf::from_str("./kiln.toml")?;

--- a/data-forwarder/src/main.rs
+++ b/data-forwarder/src/main.rs
@@ -16,8 +16,8 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::process::Command;
+use std::str::FromStr;
 use uuid::Uuid;
 
 fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
@@ -125,12 +125,12 @@ fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
     let repo = Repository::discover(curr_dir)?;
     let head = repo.head()?;
     let git_branch_name_cmd = Command::new("git")
-              .arg("name-rev")
-              .arg("--name-only")
-              .arg("--exclude=*HEAD*")
-              .arg("HEAD")
-              .output()
-              .expect("failed to execute process");
+        .arg("name-rev")
+        .arg("--name-only")
+        .arg("--exclude=*HEAD*")
+        .arg("HEAD")
+        .output()
+        .expect("failed to execute process");
 
     let git_branch_name = String::from_utf8_lossy(&git_branch_name_cmd.stdout);
     let git_commit = head.peel_to_commit()?.id().to_string();

--- a/data-forwarder/src/main.rs
+++ b/data-forwarder/src/main.rs
@@ -132,7 +132,7 @@ fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         .output()
         .ok();
 
-    let git_branch_name = String::from_utf8_lossy(&git_branch_name_cmd.stdout);
+    let git_branch_name = git_branch_name_cmd.map(|v| String::from_utf8_lossy(&v.stdout).into_owned());
     let git_commit = head.peel_to_commit()?.id().to_string();
 
     let kiln_cfg_path = PathBuf::from_str("./kiln.toml")?;
@@ -163,7 +163,7 @@ fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         event_version: EventVersion::try_from("1".to_string())?,
         event_id: EventID::try_from(Uuid::new_v4().to_hyphenated().to_string())?,
         application_name: ApplicationName::try_from(app_name.to_string())?,
-        git_branch: GitBranch::try_from(Some(git_branch_name.into_owned()))?,
+        git_branch: GitBranch::try_from(git_branch_name)?,
         git_commit_hash: GitCommitHash::try_from(git_commit)?,
         tool_name: ToolName::try_from(tool_name.to_string())?,
         tool_output: ToolOutput::try_from(tool_output)?,
@@ -188,7 +188,7 @@ fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
                 }
                 OperationResult::Retry(err_msg(err))
             }
-            Ok(mut res) => match res.status() {
+            Ok(res) => match res.status() {
                 StatusCode::OK => OperationResult::Ok(()),
                 _ => OperationResult::Err(err_msg(res.text().unwrap())),
             },

--- a/data-forwarder/src/main.rs
+++ b/data-forwarder/src/main.rs
@@ -130,7 +130,7 @@ fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         .arg("--exclude=*HEAD*")
         .arg("HEAD")
         .output()
-        .expect("failed to execute process");
+        .ok();
 
     let git_branch_name = String::from_utf8_lossy(&git_branch_name_cmd.stdout);
     let git_commit = head.peel_to_commit()?.id().to_string();

--- a/data-forwarder/src/main.rs
+++ b/data-forwarder/src/main.rs
@@ -17,6 +17,7 @@ use std::io::prelude::*;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::process::Command;
 use uuid::Uuid;
 
 fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
@@ -123,11 +124,15 @@ fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
     let curr_dir = env::current_dir()?;
     let repo = Repository::discover(curr_dir)?;
     let head = repo.head()?;
-    let git_branch_name = if head.is_branch() {
-        head.shorthand().map(|t| t.to_string())
-    } else {
-        None
-    };
+    let git_branch_name_cmd = Command::new("git")
+              .arg("name-rev")
+              .arg("--name-only")
+              .arg("--exclude=*HEAD*")
+              .arg("HEAD")
+              .output()
+              .expect("failed to execute process");
+
+    let git_branch_name = String::from_utf8_lossy(&git_branch_name_cmd.stdout);
     let git_commit = head.peel_to_commit()?.id().to_string();
 
     let kiln_cfg_path = PathBuf::from_str("./kiln.toml")?;
@@ -158,7 +163,7 @@ fn main() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         event_version: EventVersion::try_from("1".to_string())?,
         event_id: EventID::try_from(Uuid::new_v4().to_hyphenated().to_string())?,
         application_name: ApplicationName::try_from(app_name.to_string())?,
-        git_branch: GitBranch::try_from(git_branch_name)?,
+        git_branch: GitBranch::try_from(Some(git_branch_name.into_owned()))?,
         git_commit_hash: GitCommitHash::try_from(git_commit)?,
         tool_name: ToolName::try_from(tool_name.to_string())?,
         tool_output: ToolOutput::try_from(tool_output)?,


### PR DESCRIPTION
# What does this PR change?
Ensures that the branch name gets populated even in detached head state

# Why is it important?
Important to know what branch of a project was scanned using one of the kiln supported tools

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
