### PR TITLE
Kiln_lib: Upgrade Actix-web to latest beta

### DIFF
--- a/kiln_lib/Cargo.lock
+++ b/kiln_lib/Cargo.lock
@@ -18,9 +18,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.0.0-beta.4"
+version = "3.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a01f9e0681608afa887d4269a0857ac4226f09ba5ceda25939e8391c9da610a"
+checksum = "59d51c2ba06062e698a5d212d860e9fb2afc931c285ede687aaae896c8150347"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -33,8 +33,6 @@ dependencies = [
  "brotli2",
  "bytes",
  "bytestring",
- "cfg-if",
- "cookie",
  "derive_more",
  "encoding_rs",
  "flate2",
@@ -45,16 +43,17 @@ dependencies = [
  "httparse",
  "itoa",
  "language-tags",
+ "local-channel",
  "log",
  "mime",
  "once_cell",
+ "paste",
  "percent-encoding",
  "pin-project",
+ "pin-project-lite",
  "rand 0.8.3",
  "regex",
  "serde",
- "serde_json",
- "serde_urlencoded",
  "sha-1",
  "smallvec",
  "time 0.2.26",
@@ -86,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4e57bc1a3915e71526d128baf4323700bd1580bc676239e2298a4c5b001f18"
+checksum = "bc7d7cd957c9ed92288a7c3c96af81fa5291f65247a76a34dac7b6af74e52ba0"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -115,19 +114,20 @@ dependencies = [
 
 [[package]]
 name = "actix-service"
-version = "2.0.0-beta.5"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf82340ad9f4e4caf43737fd3bbc999778a268015cdc54675f60af6240bd2b05"
+checksum = "77f5f9d66a8730d0fae62c26f3424f5751e5518086628a40b7ab6fca4a705034"
 dependencies = [
  "futures-core",
+ "paste",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "actix-tls"
-version = "3.0.0-beta.4"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b1455e3f7a26d40cfc1080b571f41e8165e5a88e937ed579f7a4b3d55b0370"
+checksum = "65b7bb60840962ef0332f7ea01a57d73a24d2cb663708511ff800250bbfef569"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -142,24 +142,19 @@ dependencies = [
 
 [[package]]
 name = "actix-utils"
-version = "3.0.0-beta.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458795e09a29bc5557604f9ff6f32236fd0ee457d631672e4ec8f6a0103bb292"
+checksum = "e491cbaac2e7fc788dfff99ff48ef317e23b3cf63dbaf7aaab6418f40f92aa94"
 dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "futures-core",
- "futures-sink",
- "log",
+ "local-waker",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "actix-web"
-version = "4.0.0-beta.4"
+version = "4.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d95e50c9e32e8456220b5804867de76e97a86ab8c38b51c9edcccc0f0fddca7"
+checksum = "ff12e933051557d700b0fcad20fe25b9ca38395cc87bbc5aeaddaef17b937a2f"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -171,22 +166,25 @@ dependencies = [
  "actix-utils",
  "actix-web-codegen",
  "ahash",
- "awc",
  "bytes",
+ "cookie",
  "derive_more",
  "either",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "itoa",
+ "language-tags",
  "log",
  "mime",
+ "once_cell",
  "pin-project",
  "regex",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.4.0",
  "time 0.2.26",
  "url",
 ]
@@ -276,32 +274,6 @@ dependencies = [
  "typed-builder",
  "uuid",
  "zerocopy",
-]
-
-[[package]]
-name = "awc"
-version = "3.0.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aecd8728f6491a62b27454ea4b36fb7e50faf32928b0369b644e402c651f4e"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-rt",
- "actix-service",
- "base64",
- "bytes",
- "cfg-if",
- "derive_more",
- "futures-core",
- "itoa",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand 0.8.3",
- "serde",
- "serde_json",
- "serde_urlencoded",
 ]
 
 [[package]]
@@ -427,9 +399,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
+checksum = "ffdf8865bac3d9a3bde5bde9088ca431b11f5d37c7a578b8086af77248b76627"
 dependencies = [
  "percent-encoding",
  "time 0.2.26",
@@ -824,6 +796,7 @@ dependencies = [
  "hex",
  "http",
  "json_dotpath",
+ "mime",
  "openssl-probe",
  "rdkafka",
  "regex",
@@ -886,6 +859,24 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "local-channel"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6246c68cf195087205a0512559c97e15eaf95198bf0e206d662092cdcb03fe9f"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f9a2d3e27ce99ce2c3aad0b09b1a7b916293ea9b2bf624c13fe646fadd8da4"
 
 [[package]]
 name = "lock_api"
@@ -952,7 +943,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi",
 ]
 
@@ -1092,6 +1083,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "percent-encoding"
@@ -1503,6 +1500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
  "libc",
  "winapi",
 ]

--- a/kiln_lib/Cargo.toml
+++ b/kiln_lib/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 anyhow = "1"
 avro-rs = { version = "0.13", optional = true }
 chrono = { version = "0.4", features = [ "serde",] }
-actix-web = { version = "4.0.0-beta.4", optional = true }
+actix-web = { version = "4.0.0-beta.6", optional = true }
 hex = { version = "0.4", features = [ "serde",] }
 http = { version = "0.2", optional = true }
 serde_json = { version = "1.0", optional = true }
@@ -23,6 +23,7 @@ openssl-probe = "0.1"
 json_dotpath = { version = "1", optional = true }
 slog = { version = "2.5", features = [ "nested-values",], optional = true }
 thiserror = "1"
+mime = "0.3"
 
 [features]
 default = []

--- a/kiln_lib/src/validation.rs
+++ b/kiln_lib/src/validation.rs
@@ -627,21 +627,20 @@ impl ValidationError {
 }
 
 #[cfg(feature = "web")]
-use actix_web::HttpResponse;
+use actix_web::BaseHttpResponse;
 
 #[cfg(feature = "web")]
-use actix_web::dev::Body;
-
-#[cfg(feature = "web")]
-use actix_web::error::ResponseError;
+use actix_web::body::Body;
 
 #[cfg(feature = "web")]
 use actix_web::http::StatusCode;
 
 #[cfg(feature = "web")]
-impl Into<HttpResponse> for ValidationError {
-    fn into(self) -> HttpResponse {
-        HttpResponse::BadRequest().json(&self)
+impl Into<BaseHttpResponse<Body>> for ValidationError {
+    fn into(self) -> BaseHttpResponse<Body> {
+        BaseHttpResponse::build(StatusCode::BAD_REQUEST)
+            .content_type(mime::APPLICATION_JSON)
+            .body(serde_json::to_string(&self).unwrap())
     }
 }
 
@@ -651,7 +650,9 @@ impl actix_web::ResponseError for ValidationError {
         StatusCode::BAD_REQUEST
     }
 
-    fn error_response(&self) -> HttpResponse<Body> {
-        HttpResponse::BadRequest().json(self)
+    fn error_response(&self) -> BaseHttpResponse<Body> {
+        BaseHttpResponse::build(StatusCode::BAD_REQUEST)
+            .content_type(mime::APPLICATION_JSON)
+            .body(serde_json::to_string(&self).unwrap())
     }
 }


### PR DESCRIPTION
# What does this PR change?

Brings kiln_lib up to the latest beta for Actix_web

# Why is it important?

Keeping Kiln's dependencies up to date allows us to benefit from new features, bug fixes and performance improvements

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
