### PR TITLE
Data-collector: Fix bug that causes request path to be logged in the http.request.method field

### DIFF
--- a/data-collector/src/lib.rs
+++ b/data-collector/src/lib.rs
@@ -180,7 +180,7 @@ where
                 .map(|v| v.to_string());
 
             let http_version = format!("{:?}", req.version());
-            let http_request_method = req.path().to_owned();
+            let http_request_method = req.method().to_string();
             let url_path = req.path().to_owned();
             let url_query = req.query_string().to_string();
 


### PR DESCRIPTION
# What does this PR change?
Fixes a bug in data collector logging

# Why is it important?
Because currently the Data-Collector logs a request path where it should be logging a request method

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
