### PR TITLE
Support large kafka messages

### DIFF
--- a/data-collector/README.md
+++ b/data-collector/README.md
@@ -8,7 +8,7 @@ First, ensure you have cargo-make installed by running `cargo install cargo-make
 ## Deploying
 See the [suggested Kafka deployment](../docs/suggested_kafka_deployment.md) documentation to understand how this component should be deployed and what it needs to be able to communicate with. The data-collector container is setup with an entrypoint, so no command needs to be passed to the container when calling docker run.
 
-Tool reports are published to a Kafka topic called "ToolReports". If you do not have auto topic creation enabled for your cluster, you will need to crate this topic.
+Tool reports are published to a Kafka topic called "ToolReports". If you do not have auto topic creation enabled for your cluster, you will need to crate this topic. Please note that for the ToolReports topic we recommend changing the default kafka message size from 1MB to 10MB to support potentially large amount of tool output by setting the parameters `max.message.bytes` and `replica.fetch.max.bytes`.
 
 ## Configuration
 This component is configured using environment variables. Ensure that the environment variable `KAFKA_BOOTSTRAP_TLS` is set to a comma separated list of host:port pairs to bootstrap connectivity to your Kafka cluster over TLS.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,6 @@ services:
       KAFKA_CREATE_TOPICS: "ToolReports:6:1,DependencyEvents:6:1"
       KAFKA_MESSAGE_MAX_BYTES: 10000000
       KAFKA_REPLICA_FETCH_MAX_BYTES: 10000000
-      KAFKA_MESSAGE_MAX_BYTES: 10000000
-      KAFKA_REPLICA_FETCH_MAX_BYTES: 10000000
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./tls:/tls

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,10 @@ services:
       KAFKA_SSL_TRUSTSTORE_LOCATION: /tls/kafka.truststore.jks
       KAFKA_SSL_TRUSTSTORE_PASSWORD: password
       KAFKA_CREATE_TOPICS: "ToolReports:6:1,DependencyEvents:6:1"
+      KAFKA_MESSAGE_MAX_BYTES: 10000000
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 10000000
+      KAFKA_MESSAGE_MAX_BYTES: 10000000
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 10000000
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./tls:/tls

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -232,10 +232,10 @@ helm install kafka ./ -f kafka-values.yaml
 kubectl get pods -w -l app.kubernetes.io/name=kafka # Wait for pods to be ready
 ```
 
-* Create the Kafka topics for Kiln. The last command in the following block will print the list of Kafka topics that exist in this cluster, it should now contain "ToolReports" and "DependencyEvents"
+* Create the Kafka topics for Kiln. The last command in the following block will print the list of Kafka topics that exist in this cluster, it should now contain "ToolReports" and "DependencyEvents". Please note that for the ToolReports topic we have increased the default kafka message size from 1MB to 10MB to support larger message sizes by setting the parameters `max.message.bytes` and `replica.fetch.max.bytes`. 
 ``` shell
 export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=kafka,app.kubernetes.io/instance=kafka,app.kubernetes.io/component=kafka" -o jsonpath="{.items[0].metadata.name}")
-kubectl --namespace default exec -it $POD_NAME -- kafka-topics.sh --create --zookeeper zk-zookeeper-headless:2181 --replication-factor 3 --partitions 3 --topic ToolReports
+kubectl --namespace default exec -it $POD_NAME -- kafka-topics.sh --create --zookeeper zk-zookeeper-headless:2181 --replication-factor 3 --partitions 3 --topic ToolReports --add-config max.message.bytes=10000000 --add-config replica.fetch.max.bytes=10000000
 kubectl --namespace default exec -it $POD_NAME -- kafka-topics.sh --create --zookeeper zk-zookeeper-headless:2181 --replication-factor 3 --partitions 3 --topic DependencyEvents
 kubectl --namespace default exec -it $POD_NAME -- kafka-topics.sh --list --zookeeper zk-zookeeper-headless:2181
 ```

--- a/kiln_lib/src/kafka.rs
+++ b/kiln_lib/src/kafka.rs
@@ -129,7 +129,7 @@ pub fn build_kafka_producer(
         .set("security.protocol", "SSL")
         .set("ssl.cipher.suites", "ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256")
         .set("ssl.ca.location", cert_location.unwrap().to_string_lossy())
-        .set("max.request.size", "10000000").create()
+        .set("message.max.bytes", "10000000").create()
         .map_err(|err| err.into())
 }
 

--- a/kiln_lib/src/kafka.rs
+++ b/kiln_lib/src/kafka.rs
@@ -129,7 +129,7 @@ pub fn build_kafka_producer(
         .set("security.protocol", "SSL")
         .set("ssl.cipher.suites", "ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256")
         .set("ssl.ca.location", cert_location.unwrap().to_string_lossy())
-        .create()
+        .set("max.request.size", "10000000").create()
         .map_err(|err| err.into())
 }
 
@@ -151,7 +151,7 @@ pub fn build_kafka_consumer(
         .set("security.protocol", "SSL")
         .set("ssl.cipher.suites", "ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256")
         .set("ssl.ca.location", cert_location.unwrap().to_string_lossy())
-        .create()
+        .set("fetch.message.max.bytes", "10000000").create()
         .map_err(|err| err.into())
 }
 


### PR DESCRIPTION
# What does this PR change?
Increases the default message size limits in Kafka to allow for larger ToolReports

# Why is it important?
Yarn-audit (and other tools) that return large ToolReports can be handled

# Checklist
- [ ] Tests added/updated as appropriate
- [ ] Documentation added/updated as appropriate

If this PR introduces a new tool:
- [ ] Documentation on how to handle false positives added
- [ ] Documentation on how to configure the tool added
